### PR TITLE
NUI-5954 Combox box v2 in a popover has small font size

### DIFF
--- a/packages/bits/demo/src/components/demo/popover/popover-prevent-close-on-click/popover-prevent-close-on-click.example.component.html
+++ b/packages/bits/demo/src/components/demo/popover/popover-prevent-close-on-click/popover-prevent-close-on-click.example.component.html
@@ -14,7 +14,10 @@
         <nui-checkbox id="nui-demo-checkbox-in-popover" i18n>Hi, check me!</nui-checkbox>
         <nui-combobox id="nui-demo-popover-combobox"
                       [itemsSource]="dataset.items"
-                      placeholder="Select item" i18n-placeholder></nui-combobox>
+                      placeholder="Select item combobox" i18n-placeholder></nui-combobox>
+        <nui-combobox-v2 id="nui-demo-popover-comboboxV2" placeholder="Select item comboboxV2" i18n-placeholder>
+            <nui-select-v2-option *ngFor="let item of dataset.items" [value]="item">{{ item }}</nui-select-v2-option>
+        </nui-combobox-v2>
         <div class="mt-2 d-flex justify-content-end">
             <button id="nui-demo-custom-close-popover"
                     nui-button

--- a/packages/bits/demo/src/components/demo/popover/popover-prevent-close-on-click/popover-prevent-close-on-click.example.component.html
+++ b/packages/bits/demo/src/components/demo/popover/popover-prevent-close-on-click/popover-prevent-close-on-click.example.component.html
@@ -14,7 +14,7 @@
         <nui-checkbox id="nui-demo-checkbox-in-popover" i18n>Hi, check me!</nui-checkbox>
         <nui-combobox id="nui-demo-popover-combobox"
                       [itemsSource]="dataset.items"
-                      placeholder="Select item combobox" i18n-placeholder></nui-combobox>
+                      placeholder="Select item" i18n-placeholder></nui-combobox>
         <div class="mt-2 d-flex justify-content-end">
             <button id="nui-demo-custom-close-popover"
                     nui-button

--- a/packages/bits/demo/src/components/demo/popover/popover-prevent-close-on-click/popover-prevent-close-on-click.example.component.html
+++ b/packages/bits/demo/src/components/demo/popover/popover-prevent-close-on-click/popover-prevent-close-on-click.example.component.html
@@ -15,9 +15,6 @@
         <nui-combobox id="nui-demo-popover-combobox"
                       [itemsSource]="dataset.items"
                       placeholder="Select item combobox" i18n-placeholder></nui-combobox>
-        <nui-combobox-v2 id="nui-demo-popover-comboboxV2" placeholder="Select item comboboxV2" i18n-placeholder>
-            <nui-select-v2-option *ngFor="let item of dataset.items" [value]="item">{{ item }}</nui-select-v2-option>
-        </nui-combobox-v2>
         <div class="mt-2 d-flex justify-content-end">
             <button id="nui-demo-custom-close-popover"
                     nui-button

--- a/packages/bits/demo/src/components/demo/popover/popover-visual-test/popover-visual-test.component.html
+++ b/packages/bits/demo/src/components/demo/popover/popover-visual-test/popover-visual-test.component.html
@@ -60,7 +60,11 @@
                     <div class="mb-2">
                         <nui-combobox id="nui-demo-popover-combobox"
                                       [itemsSource]="dataset.items"
-                                      placeholder="Select item"></nui-combobox>
+                                      placeholder="Select item combo"></nui-combobox>
+                        <nui-combobox-v2 [overlayConfig]="overlayConfig" id="nui-demo-combobox-v2-in-popover" placeholder="Select item combo v2">
+                            <nui-select-v2-option *ngFor="let item of dataset.items" [value]="item">{{ item }}</nui-select-v2-option>
+                        </nui-combobox-v2>
+
                     </div>
                     <div class="d-flex justify-content-end">
                         <button nui-button

--- a/packages/bits/demo/src/components/demo/popover/popover-visual-test/popover-visual-test.component.ts
+++ b/packages/bits/demo/src/components/demo/popover/popover-visual-test/popover-visual-test.component.ts
@@ -1,4 +1,6 @@
+import { OverlayConfig } from "@angular/cdk/overlay";
 import { Component } from "@angular/core";
+import { OVERLAY_WITH_POPUP_STYLES_CLASS } from "@nova-ui/bits";
 import { Subject } from "rxjs";
 
 @Component({
@@ -11,7 +13,10 @@ export class PopoverVisualTestComponent {
         items: ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5"],
     };
     public closePopoverSubject = new Subject();
-
+    // Testing only
+    public overlayConfig: OverlayConfig = {
+        panelClass: [OVERLAY_WITH_POPUP_STYLES_CLASS, "combobox-v2-test-pane"],
+    };
     closePopover() {
         this.closePopoverSubject.next();
     }

--- a/packages/bits/demo/src/components/demo/popover/popover.module.ts
+++ b/packages/bits/demo/src/components/demo/popover/popover.module.ts
@@ -7,6 +7,7 @@ import {
     NuiDocsModule,
     NuiPopoverModule,
     NuiSelectModule,
+    NuiSelectV2Module,
     SrlcStage,
 } from "@nova-ui/bits";
 
@@ -64,6 +65,7 @@ const routes = [
         NuiPopoverModule,
         NuiCheckboxModule,
         NuiSelectModule,
+        NuiSelectV2Module,
         NuiDocsModule,
         RouterModule.forChild(routes),
     ],

--- a/packages/bits/spec/components/popover/popover.visual.ts
+++ b/packages/bits/spec/components/popover/popover.visual.ts
@@ -3,11 +3,13 @@ import { browser, by, element, ElementArrayFinder, ElementFinder } from "protrac
 import { Helpers } from "../../helpers";
 import { Camera } from "../../virtual-camera/Camera";
 
+import { CheckboxAtom } from "../checkbox/checkbox.atom";
+import { ComboboxV2Atom } from "../combobox-v2/combobox-v2.atom";
 import { PopoverAtom } from "./popover.atom";
 
 const name: string = "Popover";
 
-describe(`Visual tests: ${name}`, () => {
+fdescribe(`Visual tests: ${name}`, () => {
     let camera: Camera;
     const buttonPreventClosing: ElementFinder = element(by.id("nui-demo-button-prevent-onclick"));
     const placementCheckButtons: ElementArrayFinder = element.all(by.css(".placement-check-btn"));
@@ -17,6 +19,8 @@ describe(`Visual tests: ${name}`, () => {
     const popoverNoPadding: PopoverAtom = new PopoverAtom(element(by.id("nui-demo-popover-no-padding")));
     const popoverBasicMultiline: PopoverAtom = new PopoverAtom(element(by.id("nui-demo-popover-limited-and-multiline")));
     const popoverModal: PopoverAtom = new PopoverAtom(element(by.id("nui-demo-popover-modal")));
+    const checkboxInPopover: CheckboxAtom = new CheckboxAtom(element(by.id("nui-demo-checkbox-in-popover")));
+    const comboboxV2InPopover: ComboboxV2Atom = new ComboboxV2Atom(element(by.id("nui-demo-combobox-v2-in-popover")));
 
     beforeAll(async (done) => {
         await Helpers.prepareBrowser("popover/popover-visual-test");
@@ -31,6 +35,11 @@ describe(`Visual tests: ${name}`, () => {
         await popoverPreventClosing.togglePopover();
         await placementCheckButtons.each(async btn => await btn?.click());
         await browser.actions().mouseMove(buttonPreventClosing).perform();
+        await checkboxInPopover.toggle();
+        await comboboxV2InPopover.click();
+        await (await comboboxV2InPopover.getFirstOption()).click();
+        await comboboxV2InPopover.click();
+
         await camera.say.cheese(`Popover placement and preventClose`);
 
         await Helpers.switchDarkTheme("on");

--- a/packages/bits/spec/components/popover/popover.visual.ts
+++ b/packages/bits/spec/components/popover/popover.visual.ts
@@ -2,14 +2,14 @@ import { browser, by, element, ElementArrayFinder, ElementFinder } from "protrac
 
 import { Helpers } from "../../helpers";
 import { Camera } from "../../virtual-camera/Camera";
-
 import { CheckboxAtom } from "../checkbox/checkbox.atom";
 import { ComboboxV2Atom } from "../combobox-v2/combobox-v2.atom";
+
 import { PopoverAtom } from "./popover.atom";
 
 const name: string = "Popover";
 
-fdescribe(`Visual tests: ${name}`, () => {
+describe(`Visual tests: ${name}`, () => {
     let camera: Camera;
     const buttonPreventClosing: ElementFinder = element(by.id("nui-demo-button-prevent-onclick"));
     const placementCheckButtons: ElementArrayFinder = element.all(by.css(".placement-check-btn"));

--- a/packages/bits/src/lib/select-v2/combobox-v2/combobox-v2.component.less
+++ b/packages/bits/src/lib/select-v2/combobox-v2/combobox-v2.component.less
@@ -17,6 +17,7 @@
     min-height: @content-height;
     line-height: @input-height;
     min-width: @min-width;
+    font-size: @nui-font-size-default;
 
     &.disabled {
         .setCssVariable(color, nui-color-text-disabled);


### PR DESCRIPTION
- set a default font size for a combobox-v2 component
- updated visual tests to include combobox-v2 component with popover 
- add combobox-v2 to the example docs section with popover rich content

![image](https://user-images.githubusercontent.com/77667424/115252446-266d4a00-a134-11eb-8817-c2637a6e9173.png)
