### PR TITLE
NUI-4907-Tests-Review-and-Improvements-for-FormField-component

### DIFF
--- a/packages/bits/spec/components/form-field/form-field.e2e.ts
+++ b/packages/bits/spec/components/form-field/form-field.e2e.ts
@@ -1,7 +1,7 @@
-import {browser, by, element, ElementFinder } from "protractor";
+import { browser, by, element, ElementFinder } from "protractor";
 
-import {Atom} from "../../atom";
-import {Helpers} from "../../helpers";
+import { Atom } from "../../atom";
+import { Helpers } from "../../helpers";
 import {
     ButtonAtom,
     CheckboxAtom,
@@ -120,7 +120,7 @@ describe("USERCONTROL form-field >", () => {
         });
     });
 
-    fit("should set initial disabled state to the fields of form", async () => {
+    it("should set initial disabled state to the fields of form", async () => {
         expect(await textbox.disabled()).toBeTruthy();
         expect(await textboxNumber.isDisabled()).toBe(true);
         expect(await datepicker.isDisabled()).toBeTruthy();

--- a/packages/bits/spec/components/form-field/form-field.e2e.ts
+++ b/packages/bits/spec/components/form-field/form-field.e2e.ts
@@ -1,4 +1,4 @@
-import {browser, by, element, ElementFinder, ExpectedConditions } from "protractor";
+import {browser, by, element, ElementFinder } from "protractor";
 
 import {Atom} from "../../atom";
 import {Helpers} from "../../helpers";
@@ -15,7 +15,7 @@ import {
     SwitchAtom,
     TextboxAtom,
     TextboxNumberAtom,
-    TimepickerAtom
+    TimepickerAtom,
 } from "../public_api";
 
 describe("USERCONTROL form-field >", () => {
@@ -120,12 +120,11 @@ describe("USERCONTROL form-field >", () => {
         });
     });
 
-    it("should set initial disabled state to the fields of form", async () => {
+    fit("should set initial disabled state to the fields of form", async () => {
         expect(await textbox.disabled()).toBeTruthy();
         expect(await textboxNumber.isDisabled()).toBe(true);
         expect(await datepicker.isDisabled()).toBeTruthy();
         await datepicker.toggle();
-        await browser.wait(ExpectedConditions.presenceOf(datepicker.getElement()), 5000);
         expect(await datepicker.overlay.isOpened()).toBeFalsy();
         expect(await radioGroup.getNumberOfDisabledItems()).toBe(1);
         expect(await checkbox.isDisabled()).toBeTruthy();
@@ -205,7 +204,7 @@ describe("USERCONTROL form-field >", () => {
             await dateTimepicker.getDatePicker().acceptText("01 Jan 2020");
             // const timeToSelect = TimepickerAtom.createTimeString(2, 0);
             // await dateTimepicker.getTimePicker().textbox.acceptText(timeToSelect);
-            await dateTimepicker.getTimePicker().selectTime("2:00 AM");   
+            await dateTimepicker.getTimePicker().selectTime("2:00 AM");
             expect(await dateTimepickerModelElement.getText()).toBe("Wednesday, January 1, 2020 2:00 AM");
         });
 

--- a/packages/bits/spec/components/form-field/form-field.e2e.ts
+++ b/packages/bits/spec/components/form-field/form-field.e2e.ts
@@ -1,4 +1,4 @@
-import {browser, by, element, ElementFinder} from "protractor";
+import {browser, by, element, ElementFinder, ExpectedConditions } from "protractor";
 
 import {Atom} from "../../atom";
 import {Helpers} from "../../helpers";
@@ -15,7 +15,7 @@ import {
     SwitchAtom,
     TextboxAtom,
     TextboxNumberAtom,
-    TimepickerAtom,
+    TimepickerAtom
 } from "../public_api";
 
 describe("USERCONTROL form-field >", () => {
@@ -56,36 +56,10 @@ describe("USERCONTROL form-field >", () => {
         dateTimepickerModelElement = element(by.id("nui-form-field-test-datetimepicker-model"));
     });
 
-    it("should display caption", async () => {
-        expect(await atom.getCaptionText()).toBe("This caption is generic for all form fields");
-    });
-
-    it("should display (opt) for optional fields near caption", async () => {
-        expect(await atom.getStateText()).toBe("(optional)");
-    });
-
-    it("should display hint", async () => {
-        expect(await atom.getHintText()).toBe("Hint may be useful");
-    });
-
     it("should display hint template", async () => {
         expect(await hintWithTemplate.getHintText()).toBe("Hint template");
     });
 
-    it("should display info icon", async () => {
-        const iconAtom = atom.getInfoIcon();
-        const iconName = iconAtom.getName();
-        expect(iconName).toBe("severity_info");
-
-        const iconPopover = atom.getInfoPopover();
-        await iconPopover.openByHover();
-        const popoverAppendedToBody = iconPopover.getPopoverBody();
-        expect(await popoverAppendedToBody.getText()).toBe("Some info to show");
-
-        // Clean-up: Un-hovering icon to hide popover
-        await iconPopover.hover(undefined, { x: -1, y: -1 });
-        await iconPopover.waitForClosed();
-    });
     it("should display info from template", async () => {
         const iconAtom = atomWithTemplate.getInfoIcon();
         const iconName = await iconAtom.getName();
@@ -95,17 +69,6 @@ describe("USERCONTROL form-field >", () => {
         await iconPopover.openByHover();
         const popoverAppendedToBody = iconPopover.getPopoverBody();
         expect(await popoverAppendedToBody.getText()).toBe("Template with link");
-
-        // Clean-up: Un-hovering icon to hide popover
-        await iconPopover.hover(undefined, { x: -1, y: -1 });
-        await iconPopover.waitForClosed();
-    });
-
-    it("should display info icon with popover", async () => {
-        const iconPopover = atom.getInfoPopover();
-        await iconPopover.open();
-        const popoverAppendedToBody = iconPopover.getPopoverBody();
-        expect(await popoverAppendedToBody.getText()).toBe("Some info to show");
 
         // Clean-up: Un-hovering icon to hide popover
         await iconPopover.hover(undefined, { x: -1, y: -1 });
@@ -162,6 +125,7 @@ describe("USERCONTROL form-field >", () => {
         expect(await textboxNumber.isDisabled()).toBe(true);
         expect(await datepicker.isDisabled()).toBeTruthy();
         await datepicker.toggle();
+        await browser.wait(ExpectedConditions.presenceOf(datepicker.getElement()), 5000);
         expect(await datepicker.overlay.isOpened()).toBeFalsy();
         expect(await radioGroup.getNumberOfDisabledItems()).toBe(1);
         expect(await checkbox.isDisabled()).toBeTruthy();
@@ -183,15 +147,18 @@ describe("USERCONTROL form-field >", () => {
         it("should dynamically enable texbox", async () => {
             expect(await textbox.disabled()).toBeFalsy();
         });
+
         it("should dynamically enable texbox-number", async () => {
             expect(await textboxNumber.isDisabled()).toBe(false);
         });
+
         it("should dynamically enable datepicker", async () => {
             expect(await datepicker.isDisabled()).toBeFalsy();
             await datepicker.toggle();
             expect(await datepicker.overlay.isOpened()).toBeTruthy();
             await datepicker.toggle();
         });
+
         it("should dynamically enable radioGroup", async () => {
             expect(await radioGroup.getNumberOfDisabledItems()).toBe(0);
         });
@@ -199,20 +166,23 @@ describe("USERCONTROL form-field >", () => {
         it("should dynamically enable checkbox", async () => {
             expect(await checkbox.isDisabled()).toBeFalsy();
         });
+
         it("should dynamically enable checkbox-group", async () => {
             expect(await checkboxGroup.isDisabled()).toBeFalsy();
         });
 
-
         it("should dynamically enable select", async () => {
             expect(await select.isSelectDisabled()).toBeFalsy();
         });
+
         it("should dynamically enable combobox", async () => {
             expect(await combobox.isSelectDisabled()).toBeFalsy();
         });
+
         it("should dynamically enable switch", async () => {
             expect(await switchElement.disabled()).toBeFalsy();
         });
+
         it("should dynamically enable timepicker", async () => {
             expect(await timepicker.textbox.disabled()).toBeFalsy();
             await timepicker.toggle();
@@ -227,21 +197,20 @@ describe("USERCONTROL form-field >", () => {
             await timepicker.icon.getElement().click();
             expect(await timepicker.textbox.input.getId())
                 .toEqual(await (await browser.switchTo().activeElement()).getId());
-
             await timepicker.icon.getElement().click();
         });
 
-        it("should change model for dateTimePicker", async () => {
+        xit("should change model for dateTimePicker", async () => { // review this test after NUI-6067 fixed
+            await dateTimepicker.getDatePicker().deleteTextManually();
             await dateTimepicker.getDatePicker().acceptText("01 Jan 2020");
-            const timeToSelect = TimepickerAtom.createTimeString(2, 0);
-            await dateTimepicker.getTimePicker().textbox.acceptText(timeToSelect);
-
-            expect(dateTimepickerModelElement.getText()).toBe("Wednesday, January 1, 2020 2:00 AM");
+            // const timeToSelect = TimepickerAtom.createTimeString(2, 0);
+            // await dateTimepicker.getTimePicker().textbox.acceptText(timeToSelect);
+            await dateTimepicker.getTimePicker().selectTime("2:00 AM");   
+            expect(await dateTimepickerModelElement.getText()).toBe("Wednesday, January 1, 2020 2:00 AM");
         });
 
         it("should disable all components back", async () => {
             await toggleButton.click();
-
             expect(await textbox.disabled()).toBeTruthy();
             expect(await textboxNumber.isDisabled()).toBe(true);
             expect(await datepicker.isDisabled()).toBeTruthy();


### PR DESCRIPTION
- Deleted a few e2e tests which are duplicated by visual tests.
- Disabled "should change model for dateTimePicker" test because of bug (should be reviewed after NUI-6067 fixed).