### PR TITLE
NUI-6158-Formatters-are-not-validated-when-slightly-changing-query

### DIFF
--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/table-columns-configuration-v2.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/table-columns-configuration-v2.component.ts
@@ -13,7 +13,7 @@ import {
     SimpleChanges,
     ViewEncapsulation,
 } from "@angular/core";
-import { FormArray, FormBuilder, FormControl, FormGroup } from "@angular/forms";
+import { AbstractControl, FormArray, FormBuilder, FormControl, FormGroup } from "@angular/forms";
 import { DialogService, EventBus, IDataField, IDataSource, IEvent, uuid } from "@nova-ui/bits";
 import isUndefined from "lodash/isUndefined";
 import values from "lodash/values";
@@ -157,7 +157,7 @@ export class TableColumnsConfigurationV2Component implements OnInit, IHasForm, O
             // Nova's markAsTouched function gets attached to formControl during init of TableColumnConfigurationComponent,
             // must be pass to newly created formControl here otherwise gets lost and column validation doesn't get triggered.
             const colControl = cols.controls.find(
-                (cControl: FormControl) => cControl.value.id === c.id
+                (cControl: AbstractControl) => cControl.value.id === c.id
             );
             if (colControl) {
                 fc.markAsTouched = colControl.markAsTouched;

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/table-columns-configuration-v2.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/table-columns-configuration-v2.component.ts
@@ -153,6 +153,16 @@ export class TableColumnsConfigurationV2Component implements OnInit, IHasForm, O
         cols.controls = columns.map(c => {
             const fc = new FormControl(c);
             fc.setParent(cols);
+
+            // Nova's markAsTouched function gets attached to formControl during init of TableColumnConfigurationComponent,
+            // must be pass to newly created formControl here otherwise gets lost and column validation doesn't get triggered.
+            const colControl = cols.controls.find(
+                (cControl: FormControl) => cControl.value.id === c.id
+            );
+            if (colControl) {
+                fc.markAsTouched = colControl.markAsTouched;
+            }
+
             return fc;
         });
         cols.updateValueAndValidity({ emitEvent });


### PR DESCRIPTION
Nova's markAsTouched function after attaching to formControl during init of [TableColumnConfigurationComponent ](https://github.com/solarwinds/nova/blob/061ffea49f4ad3d2f283af3c8ea488a067949b9b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/table-column-configuration/table-column-configuration.component.ts#L54) gets lost when updating column and creating a new [formControl](https://github.com/solarwinds/nova/blob/061ffea49f4ad3d2f283af3c8ea488a067949b9b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/table-columns-configuration-v2.component.ts#L154).