### PR TITLE
(circleci) update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.2.5
 jobs:
     bits-build:
         working_directory: ~/nova
@@ -73,6 +75,8 @@ jobs:
         docker:
             -   image: cimg/node:16.14-browsers
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -85,6 +89,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/bits
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -111,6 +117,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/bits
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -129,6 +137,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/bits
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -255,6 +265,8 @@ jobs:
             # Needed for daylight saving time tests
             TZ: "America/Chicago"
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -267,6 +279,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/charts
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -293,6 +307,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/charts
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -421,6 +437,8 @@ jobs:
         docker:
             -   image: cimg/node:16.14-browsers
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -433,6 +451,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/dashboards
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -459,6 +479,8 @@ jobs:
         environment:
             PROJECT_DIR: ~/nova/packages/dashboards
         steps:
+            -   browser-tools/install-chrome
+            -   browser-tools/install-chromedriver
             -   attach_workspace:
                     at: ~/nova
             -   run:
@@ -682,7 +704,7 @@ workflows:
                                 - main
                                 - /^release\/.*/
                                 - next
-                                
+
     nova-release:
         jobs:
             -   release-approval:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     bits-build:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             PROJECT_DIR: ./packages/bits
             BUILD_COUNTER: << pipeline.number >>
@@ -71,7 +71,7 @@ jobs:
     bits-unit-test:
         working_directory: ~/nova/packages/bits
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         steps:
             -   attach_workspace:
                     at: ~/nova
@@ -145,7 +145,7 @@ jobs:
     bits-pack:
         working_directory: ~/nova/packages/bits
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         steps:
             -   attach_workspace:
                     at: ~/nova
@@ -159,7 +159,7 @@ jobs:
     bits-publish:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             PROJECT_DIR: ./packages/bits
         steps:
@@ -177,7 +177,7 @@ jobs:
     charts-build:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             PROJECT_DIR: ./packages/charts
             BUILD_COUNTER: << pipeline.number >>
@@ -250,7 +250,7 @@ jobs:
     charts-unit-test:
         working_directory: ~/nova/packages/charts
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             # Needed for daylight saving time tests
             TZ: "America/Chicago"
@@ -309,7 +309,7 @@ jobs:
     charts-pack:
         working_directory: ~/nova/packages/charts
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         steps:
             -   attach_workspace:
                     at: ~/nova
@@ -323,7 +323,7 @@ jobs:
     charts-publish:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             PROJECT_DIR: ./packages/charts
         steps:
@@ -341,7 +341,7 @@ jobs:
     dashboards-build:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             PROJECT_DIR: ./packages/dashboards
             BUILD_COUNTER: << pipeline.number >>
@@ -419,7 +419,7 @@ jobs:
     dashboards-unit-test:
         working_directory: ~/nova/packages/dashboards
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         steps:
             -   attach_workspace:
                     at: ~/nova
@@ -475,7 +475,7 @@ jobs:
     dashboards-pack:
         working_directory: ~/nova/packages/dashboards
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         steps:
             -   attach_workspace:
                     at: ~/nova
@@ -489,7 +489,7 @@ jobs:
     dashboards-publish:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12-browsers
+            -   image: cimg/node:16.14-browsers
         environment:
             PROJECT_DIR: ./packages/dashboards
         steps:
@@ -507,7 +507,7 @@ jobs:
     nova-docs:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12
+            -   image: cimg/node:16.14
         environment:
             NOVA_DIR: ~/nova
         steps:
@@ -521,7 +521,7 @@ jobs:
     nova-docs-cleanup:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12
+            -   image: cimg/node:16.14
         environment:
             NOVA_DIR: ~/nova
         steps:
@@ -533,7 +533,7 @@ jobs:
     release-prep:
         working_directory: ~/nova
         docker:
-            -   image: circleci/node:12
+            -   image: cimg/node:16.14
         environment:
             SOURCE_BRANCH: main
             # TODO: Change to false


### PR DESCRIPTION
- circleci is deprecating docker images from circleci/* namespace
- updated to next-gen cimg/*