### PR TITLE
Fix default behavior of links in widget header

### DIFF
--- a/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.ts
+++ b/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.ts
@@ -149,9 +149,8 @@ export class WidgetHeaderComponent implements OnInit, OnDestroy, AfterViewInit {
             if (link) {
                 target.setAttribute("href", link);
             }
-            return true;
         }
-        return !!this.url;
+        return true;
     }
 
 }

--- a/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.ts
+++ b/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.ts
@@ -151,7 +151,7 @@ export class WidgetHeaderComponent implements OnInit, OnDestroy, AfterViewInit {
             }
             return true;
         }
-        return false;
+        return !!this.url;
     }
 
 }


### PR DESCRIPTION
Statically configured links in widget header are not working in case HeaderLinkProvider is not defined.