### PR TITLE
set git eol handling proper for prettier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+[core]
+autocrlf=false
+eol=lf


### PR DESCRIPTION
without this prettier can throw errors on windows machines when global core.autocrlf=true