### PR TITLE
cci/fix-git-and-build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+[core]
+autocrlf=false
+eol=lf

--- a/scripts/deploy-docs
+++ b/scripts/deploy-docs
@@ -73,7 +73,6 @@ mv ./nova-docs.zip ../
 # push changes to the repo
 git config user.email "circleci@circleci"
 git config user.name "${GITHUB_USER_NAME}"
-git remote set-url origin https://$GITHUB_USER_NAME:$GITHUB_TOKEN@github.com/solarwinds/nova-docs.git
 git add .
 git commit -m "add docs" --allow-empty
 git pull -X theirs --no-rebase


### PR DESCRIPTION
- add `.gitattributes` to prevent line ending issues
- fix deploy-docs script to use only single docs repo reference