### PR TITLE
Add RiskScore Component to the Bits package #639

### DIFF
--- a/packages/bits/demo/src/components/app/app-routing.module.ts
+++ b/packages/bits/demo/src/components/app/app-routing.module.ts
@@ -203,6 +203,10 @@ const appRoutes: Routes = [
             import("../demo/runtime-i18n/runtime-i18n.module"),
     },
     {
+        path: "risk-score",
+        loadChildren: async () => import("../demo/risk-score/risk-score.module"),
+    },
+    {
         path: "search",
         loadChildren: async () => import("../demo/search/search.module"),
     },

--- a/packages/bits/demo/src/components/app/app-routing.module.ts
+++ b/packages/bits/demo/src/components/app/app-routing.module.ts
@@ -204,7 +204,8 @@ const appRoutes: Routes = [
     },
     {
         path: "risk-score",
-        loadChildren: async () => import("../demo/risk-score/risk-score.module"),
+        loadChildren: async () =>
+            import("../demo/risk-score/risk-score.module"),
     },
     {
         path: "search",

--- a/packages/bits/demo/src/components/demo/risk-score/index.ts
+++ b/packages/bits/demo/src/components/demo/risk-score/index.ts
@@ -1,0 +1,22 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+export * from "./risk-score-basic/risk-score-basic.example.component";
+export * from "./risk-score-docs/risk-score-docs.example.component";

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.html
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.html
@@ -1,0 +1,41 @@
+<nui-textbox-number 
+    [minValue]="-1"
+    [maxValue]="11"
+    [value]="value"
+    [step]="0.1"
+    (valueChange)="valueChanged($event)"
+></nui-textbox-number>
+
+<br>
+
+<div class="">
+    Default font size without title:
+    <nui-risk-score
+        [level]="value"
+        minLevel="0"
+        maxLevel="10"
+    ></nui-risk-score>
+</div>
+
+<div>
+    25px font size with title:
+    <nui-risk-score
+        [level]="value"
+        minLevel="0"
+        maxLevel="10"
+        title="Risk Score"
+        style="font-size: 24px;"
+    ></nui-risk-score>
+</div>
+
+<div>
+    40px font size with title-score:
+    <nui-risk-score
+        [level]="value"
+        minLevel="0"
+        maxLevel="10"
+        [title]="value"
+        style="font-size: 40px;"
+    ></nui-risk-score>
+</div>
+

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.html
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.html
@@ -1,4 +1,4 @@
-<nui-textbox-number 
+<nui-textbox-number
     [minValue]="-1"
     [maxValue]="11"
     [value]="value"
@@ -6,15 +6,11 @@
     (valueChange)="valueChanged($event)"
 ></nui-textbox-number>
 
-<br>
+<br />
 
 <div class="">
     Default font size without title:
-    <nui-risk-score
-        [level]="value"
-        minLevel="0"
-        maxLevel="10"
-    ></nui-risk-score>
+    <nui-risk-score [level]="value" minLevel="0" maxLevel="10"></nui-risk-score>
 </div>
 
 <div>
@@ -24,7 +20,7 @@
         minLevel="0"
         maxLevel="10"
         title="Risk Score"
-        style="font-size: 24px;"
+        style="font-size: 24px"
     ></nui-risk-score>
 </div>
 
@@ -35,7 +31,6 @@
         minLevel="0"
         maxLevel="10"
         [title]="value"
-        style="font-size: 40px;"
+        style="font-size: 40px"
     ></nui-risk-score>
 </div>
-

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.ts
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.ts
@@ -25,11 +25,9 @@ import { Component } from "@angular/core";
     templateUrl: "risk-score-basic.example.component.html",
 })
 export class RiskScoreBasicExampleComponent {
-
     public value: number = 3.7;
 
-
-    public valueChanged(value: number): void{
+    public valueChanged(value: number): void {
         this.value = value;
     }
 }

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.ts
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-basic/risk-score-basic.example.component.ts
@@ -1,0 +1,35 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { Component } from "@angular/core";
+
+@Component({
+    selector: "nui-risk-score-basic-example",
+    templateUrl: "risk-score-basic.example.component.html",
+})
+export class RiskScoreBasicExampleComponent {
+
+    public value: number = 3.7;
+
+
+    public valueChanged(value: number): void{
+        this.value = value;
+    }
+}

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-docs/risk-score-docs.example.component.html
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-docs/risk-score-docs.example.component.html
@@ -6,10 +6,9 @@
 </ul>
 <h1>Basic Usage</h1>
 <p>
-    To use the risk score component add an <code>&lt;nui-risk-score&gt;</code> to your
-    template.
+    To use the risk score component add an
+    <code>&lt;nui-risk-score&gt;</code> to your template.
 </p>
 <nui-example-wrapper filenamePrefix="search-basic" exampleTitle="Basic Usage">
     <nui-risk-score-basic-example></nui-risk-score-basic-example>
 </nui-example-wrapper>
-

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-docs/risk-score-docs.example.component.html
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-docs/risk-score-docs.example.component.html
@@ -1,0 +1,15 @@
+<h2>Required Modules</h2>
+<ul>
+    <li>
+        <code>NuiRiskScoreModule</code>
+    </li>
+</ul>
+<h1>Basic Usage</h1>
+<p>
+    To use the risk score component add an <code>&lt;nui-risk-score&gt;</code> to your
+    template.
+</p>
+<nui-example-wrapper filenamePrefix="search-basic" exampleTitle="Basic Usage">
+    <nui-risk-score-basic-example></nui-risk-score-basic-example>
+</nui-example-wrapper>
+

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score-docs/risk-score-docs.example.component.ts
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score-docs/risk-score-docs.example.component.ts
@@ -1,0 +1,27 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { Component } from "@angular/core";
+
+@Component({
+    selector: "nui-risk-score-docs-example",
+    templateUrl: "./risk-score-docs.example.component.html",
+})
+export class RiskScoreDocsExampleComponent {}

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score.module.ts
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score.module.ts
@@ -28,10 +28,10 @@ import {
     SrlcStage,
 } from "@nova-ui/bits";
 
-import { 
+import {
     RiskScoreBasicExampleComponent,
-    RiskScoreDocsExampleComponent
- } from "./index";
+    RiskScoreDocsExampleComponent,
+} from "./index";
 
 const routes = [
     {
@@ -51,7 +51,7 @@ const routes = [
         NuiDocsModule,
         NuiTextboxModule,
         NuiRiskScoreModule,
-        RouterModule.forChild(routes)
+        RouterModule.forChild(routes),
     ],
     declarations: [
         RiskScoreBasicExampleComponent,

--- a/packages/bits/demo/src/components/demo/risk-score/risk-score.module.ts
+++ b/packages/bits/demo/src/components/demo/risk-score/risk-score.module.ts
@@ -1,0 +1,62 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+
+import {
+    NuiDocsModule,
+    NuiRiskScoreModule,
+    NuiTextboxModule,
+    SrlcStage,
+} from "@nova-ui/bits";
+
+import { 
+    RiskScoreBasicExampleComponent,
+    RiskScoreDocsExampleComponent
+ } from "./index";
+
+const routes = [
+    {
+        path: "",
+        component: RiskScoreDocsExampleComponent,
+        data: {
+            srlc: {
+                stage: SrlcStage.ga,
+            },
+            showThemeSwitcher: true,
+        },
+    },
+];
+
+@NgModule({
+    imports: [
+        NuiDocsModule,
+        NuiTextboxModule,
+        NuiRiskScoreModule,
+        RouterModule.forChild(routes)
+    ],
+    declarations: [
+        RiskScoreBasicExampleComponent,
+        RiskScoreDocsExampleComponent,
+    ],
+    exports: [RouterModule],
+})
+export default class RiskScoreModule {}

--- a/packages/bits/src/lib/docs/example-wrapper/plunker-files.ts
+++ b/packages/bits/src/lib/docs/example-wrapper/plunker-files.ts
@@ -78,6 +78,7 @@ import {
     NuiProgressModule,
     NuiRadioModule,
     NuiRepeatModule,
+    NuiRiskScoreModule
     NuiSearchModule,
     NuiSelectorModule,
     NuiSorterModule,
@@ -156,6 +157,7 @@ export class App {
         NuiProgressModule,
         NuiRadioModule,
         NuiRepeatModule,
+        NuiRiskScoreModule,
         NuiSearchModule,
         NuiSelectorModule,
         NuiSorterModule,

--- a/packages/bits/src/lib/risk-score/risk-score.component.html
+++ b/packages/bits/src/lib/risk-score/risk-score.component.html
@@ -1,0 +1,10 @@
+<div class="nui-risk-score" [title]="level">
+    <div class="nui-risk-score__float" [style.margin-left.px]="floatOffset">
+        <div class="nui-risk-score__float-title" *ngIf="title !== undefined">
+            {{ title }}
+        </div>
+        <div class="nui-risk-score__float-path"></div>
+    </div>
+
+    <div class="nui-risk-score__color-line" #colorLine></div>
+</div>

--- a/packages/bits/src/lib/risk-score/risk-score.component.less
+++ b/packages/bits/src/lib/risk-score/risk-score.component.less
@@ -1,0 +1,40 @@
+@import (reference) "../../styles/nui-framework-variables.less";
+@import (reference) "../../styles/mixins.less";
+
+@gradient: linear-gradient(
+    90deg,
+    @nui-color-semantic-ok 0%,
+    @nui-color-semantic-warning 35%,
+    @nui-color-semantic-critical 70%,
+    @nui-color-semantic-down 100%
+);
+
+
+.nui-risk-score {
+    &__color-line {
+        height: 0.65em;
+        .setCssVariable(background, gradient);
+    }
+
+    &__float {
+        font-size: 0.35em;
+
+        &-title {
+            font-size: 1.4em;
+            font-weight: bold;
+            .setCssVariable(color, nui-color-text-secondary);
+            text-align: center;
+            white-space: nowrap;
+            display: inline-block;
+            transform: translateX(-50%);
+        }
+
+        &-path {
+            transform: translateX(-50%);
+            width: 2em;
+            height: 1em;
+            .setCssVariable(background-color, nui-color-text-default);
+            clip-path: polygon(0 0%, 50% 100%, 100% 0);
+        }
+    }
+}

--- a/packages/bits/src/lib/risk-score/risk-score.component.less
+++ b/packages/bits/src/lib/risk-score/risk-score.component.less
@@ -9,7 +9,6 @@
     @nui-color-semantic-down 100%
 );
 
-
 .nui-risk-score {
     &__color-line {
         height: 0.65em;

--- a/packages/bits/src/lib/risk-score/risk-score.component.spec.ts
+++ b/packages/bits/src/lib/risk-score/risk-score.component.spec.ts
@@ -1,0 +1,42 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { DebugElement } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { RiskScoreComponent } from "./risk-score.component";
+
+describe("components >", () => {
+    describe("search >", () => {
+        let subject: RiskScoreComponent;
+        let fixture: ComponentFixture<RiskScoreComponent>;
+        let debugElement: DebugElement;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [],
+                declarations: [RiskScoreComponent],
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(RiskScoreComponent);
+            subject = fixture.componentInstance;
+            debugElement = fixture.debugElement;
+        });
+    });
+});

--- a/packages/bits/src/lib/risk-score/risk-score.component.spec.ts
+++ b/packages/bits/src/lib/risk-score/risk-score.component.spec.ts
@@ -23,20 +23,64 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RiskScoreComponent } from "./risk-score.component";
 
 describe("components >", () => {
-    describe("search >", () => {
+    describe("risk-score >", () => {
         let subject: RiskScoreComponent;
         let fixture: ComponentFixture<RiskScoreComponent>;
         let debugElement: DebugElement;
 
+        const minValue = 0;
+        const maxValue = 10;
+        let width = 0;
+
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [],
+                providers: [],
                 declarations: [RiskScoreComponent],
             }).compileComponents();
 
             fixture = TestBed.createComponent(RiskScoreComponent);
-            subject = fixture.componentInstance;
             debugElement = fixture.debugElement;
+
+            subject = fixture.componentInstance;
+            subject.level = 1;
+            subject.minLevel = minValue;
+            subject.maxLevel = maxValue;
+            subject.ngAfterViewInit();
+            width = subject["colorLine"].nativeElement.offsetWidth;
+        });
+
+        it("should create", () => {
+            expect(subject).toBeTruthy();
+        });
+
+        it("level = 1(between min and max). should provide floatOffset greater than 0 and less than 100", () => {
+            expect(subject.floatOffset).toBeGreaterThan(0);
+            expect(subject.floatOffset).toBeLessThan(width);
+        });
+
+        it("level = min. should provide floatOffset equal to 0", () => {
+            subject.level = minValue;
+            subject.ngOnChanges({});
+            expect(subject.floatOffset).toEqual(0);
+        });
+
+        it("level = max. should provide floatOffset equal to 100", () => {
+            subject.level = maxValue;
+            subject.ngOnChanges({});
+            expect(subject.floatOffset).toEqual(width);
+        });
+
+        it("level < min. should provide floatOffset equal to 0", () => {
+            subject.level = minValue - 1;
+            subject.ngOnChanges({});
+            expect(subject.floatOffset).toEqual(0);
+        });
+
+        it("level > max. should provide floatOffset equal to 100", () => {
+            subject.level = maxValue + 1;
+            subject.ngOnChanges({});
+            expect(subject.floatOffset).toEqual(width);
         });
     });
 });

--- a/packages/bits/src/lib/risk-score/risk-score.component.ts
+++ b/packages/bits/src/lib/risk-score/risk-score.component.ts
@@ -1,0 +1,125 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import {
+    AfterViewInit,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    Input,
+    NgZone,
+    OnChanges,
+    OnDestroy,
+    SimpleChanges,
+    ViewChild,
+    ViewEncapsulation,
+} from "@angular/core";
+import { BehaviorSubject } from "rxjs";
+
+/**
+ * Component for displaying risk level from severity 'OK' to 'Critical'
+ */
+@Component({
+    selector: "nui-risk-score",
+    host: {
+        class: "nui-risk-score",
+    },
+    templateUrl: "./risk-score.component.html",
+    styleUrls: ["./risk-score.component.less"],
+    encapsulation: ViewEncapsulation.None,
+})
+
+// <example-url>./../examples/index.html#/risk-score</example-url>
+export class RiskScoreComponent implements OnChanges, AfterViewInit, OnDestroy {
+    @ViewChild("colorLine") private colorLine!: ElementRef;
+
+    @Input()
+    public level: number = 0;
+
+    @Input()
+    public minLevel: number = 0;
+
+    @Input()
+    public maxLevel: number = 100;
+
+    @Input()
+    public title?: string;
+
+    public floatOffset: number = 0;
+
+    private resizeObserver: ResizeObserver;
+    private colorLineWidth$: BehaviorSubject<number>;
+
+    constructor(
+        private changeDetectorRef: ChangeDetectorRef,
+        private ngZone: NgZone
+    ) {
+        this.colorLineWidth$ = new BehaviorSubject<number>(0);
+        this.resizeObserver = new ResizeObserver((entries) =>
+            this.colorLineWidth$.next(entries[0].contentRect.width)
+        );
+    }
+
+    public ngAfterViewInit(): void {
+        this.colorLineWidth$.subscribe(this.updateOffset.bind(this));
+
+        if (this.colorLine === undefined) {
+            return;
+        }
+
+        this.ngZone.runOutsideAngular(() => {
+            this.resizeObserver.observe(this.colorLine.nativeElement);
+        });
+        this.colorLineWidth$.next(this.colorLine.nativeElement.offsetWidth);
+    }
+
+    public ngOnDestroy(): void {
+        if (this.resizeObserver !== undefined && this.colorLine !== undefined) {
+            this.resizeObserver.unobserve(this.colorLine.nativeElement);
+            this.resizeObserver.disconnect();
+        }
+
+        this.colorLineWidth$.unsubscribe();
+    }
+
+    public ngOnChanges(changes: SimpleChanges) {
+        this.updateOffset(this.colorLineWidth$.getValue());
+    }
+
+    private updateOffset(width: number): void {
+
+        if (this.minLevel >= this.maxLevel){
+            console.error("RiskScoreComponent - minLevel >= maxLevel");
+            return;
+        }
+
+        const level = this.clamp(this.level, this.minLevel, this.maxLevel);
+
+        const scaleInterval = this.maxLevel - this.minLevel;
+        const widthPerOneLevel = width / scaleInterval;
+        this.floatOffset = widthPerOneLevel * (level - this.minLevel);
+
+        this.changeDetectorRef.detectChanges();
+    }
+
+    private clamp(a: number, min: number = 0, max: number = 1):number{
+        return Math.min(max, Math.max(min, a));
+    }
+}

--- a/packages/bits/src/lib/risk-score/risk-score.component.ts
+++ b/packages/bits/src/lib/risk-score/risk-score.component.ts
@@ -47,7 +47,7 @@ import { BehaviorSubject } from "rxjs";
 })
 
 // <example-url>./../examples/index.html#/risk-score</example-url>
-export class RiskScoreComponent implements OnChanges, AfterViewInit, OnDestroy {
+export class RiskScoreComponent implements AfterViewInit, OnChanges, OnDestroy {
     @ViewChild("colorLine") private colorLine!: ElementRef;
 
     @Input()

--- a/packages/bits/src/lib/risk-score/risk-score.component.ts
+++ b/packages/bits/src/lib/risk-score/risk-score.component.ts
@@ -104,8 +104,7 @@ export class RiskScoreComponent implements OnChanges, AfterViewInit, OnDestroy {
     }
 
     private updateOffset(width: number): void {
-
-        if (this.minLevel >= this.maxLevel){
+        if (this.minLevel >= this.maxLevel) {
             console.error("RiskScoreComponent - minLevel >= maxLevel");
             return;
         }
@@ -119,7 +118,7 @@ export class RiskScoreComponent implements OnChanges, AfterViewInit, OnDestroy {
         this.changeDetectorRef.detectChanges();
     }
 
-    private clamp(a: number, min: number = 0, max: number = 1):number{
+    private clamp(a: number, min: number = 0, max: number = 1): number {
         return Math.min(max, Math.max(min, a));
     }
 }

--- a/packages/bits/src/lib/risk-score/risk-score.module.ts
+++ b/packages/bits/src/lib/risk-score/risk-score.module.ts
@@ -1,0 +1,35 @@
+// © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { NgModule } from "@angular/core";
+
+import { NuiCommonModule } from "../../common/common.module";
+import { RiskScoreComponent } from "./risk-score.component";
+
+/**
+ * @ignore
+ */
+@NgModule({
+    imports: [NuiCommonModule],
+    declarations: [RiskScoreComponent],
+    exports: [RiskScoreComponent],
+    providers: [],
+})
+export class NuiRiskScoreModule {}

--- a/packages/bits/src/nui-api.ts
+++ b/packages/bits/src/nui-api.ts
@@ -56,6 +56,7 @@ export { NuiPopoverModule } from "./lib/popover/popover.module";
 export { NuiProgressModule } from "./lib/progress/progress.module";
 export { NuiRadioModule } from "./lib/radio/radio.module";
 export { NuiRepeatModule } from "./lib/repeat/repeat.module";
+export { NuiRiskScoreModule } from "./lib/risk-score/risk-score.module";
 export { NuiSearchModule } from "./lib/search/search.module";
 export { NuiSelectorModule } from "./lib/selector/selector.module";
 export { NuiSorterModule } from "./lib/sorter/sorter.module";

--- a/packages/bits/src/public_api.ts
+++ b/packages/bits/src/public_api.ts
@@ -44,6 +44,7 @@ export { PanelComponent } from "./lib/panel/panel.component";
 export { ButtonComponent } from "./lib/button/button.component";
 export { BusyComponent } from "./lib/busy/busy.component";
 export { ImageComponent } from "./lib/image/image.component";
+export { RiskScoreComponent } from "./lib/risk-score/risk-score.component";
 export { SearchComponent } from "./lib/search/search.component";
 export { TextboxComponent } from "./lib/textbox/textbox.component";
 export { RepeatItemComponent } from "./lib/repeat/repeat-item/repeat-item.component";


### PR DESCRIPTION
## Related Jira item

https://swicloud.atlassian.net/browse/OO-23867

## Issue
https://github.com/solarwinds/nova/issues/639

## Description
Add Fusion shared 'Risk Score' component

## Screenshots (if applicable)
mockup
![image](https://github.com/solarwinds/orion/assets/40260984/89c8d8b7-04ca-4c86-a38b-82399119045b)

/components/RiskScoreComponent.html#example
![image](https://github.com/solarwinds/nova/assets/40260984/2feac6ec-0869-4b27-a074-dff6f8b323f2)

## Definition of done

- [x] Unit and E2E tests are written (or will be in scope of another PR)
- [x] Feature toggling is applied - Not Applicable
- [ ] Performance impact was considered
- [x] The security and privacy aspect has been considered - Not Applicable
- [x] Demo mode is considered - Not Applicable