### PR TITLE
fix: invalid angular-gridster2 peer dep

### DIFF
--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -110,7 +110,7 @@
   "peerDependencies": {
     "@nova-ui/bits": "~15.0.3-0",
     "@nova-ui/charts": "~15.0.3-0",
-    "angular-gridster2": "^13.3.0 || ^14.0.0",
+    "angular-gridster2": "^15.0.0",
     "d3": "^5.9.2",
     "d3-selection-multi": "^1.0.1"
   },


### PR DESCRIPTION
## Frontend Pull Request Description

Fixes invalid peer dependency for `angular-gridster2`
