### PR TITLE
Fix the issue with overlay positioning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [15.0.6] 2024-05-13
+
+### Bugfix
+
+-   `@nova-ui/bits` | Properly show _niuMenuComponent_ popup when menu button is located at the bottom right corner of the viewport.
+
 ## [12.0.43] 📅 20023-04-09
 
 ### Added

--- a/packages/bits/scripts/compile-demo-paths.js
+++ b/packages/bits/scripts/compile-demo-paths.js
@@ -24,7 +24,7 @@ const getFilesRecursively = (directory) => {
 getFilesRecursively(dir);
 
 const trimmedFiles = files.map((filePath) =>
-    filePath.replaceAll("\\", "/").replace(dir, "")
+    filePath.replace(/\\/g, "/").replace(dir, "")
 );
 
 fs.writeFileSync(

--- a/packages/bits/src/lib/popup-adapter/popup-adapter.component.ts
+++ b/packages/bits/src/lib/popup-adapter/popup-adapter.component.ts
@@ -272,9 +272,8 @@ export class PopupComponent
         const bottomRight: ConnectedPosition = {
             originX: "end",
             originY: "bottom",
-            overlayX: "center",
+            overlayX: "end",
             overlayY: "top",
-            panelClass: "translate-right",
         };
         const bottomLeft: ConnectedPosition = {
             originX: "end",
@@ -285,9 +284,8 @@ export class PopupComponent
         const rightTop: ConnectedPosition = {
             originX: "end",
             originY: "top",
-            overlayX: "center",
+            overlayX: "end",
             overlayY: "bottom",
-            panelClass: "translate-right",
         };
 
         if (this.directionTop && this.directionRight) {

--- a/packages/bits/src/styles/cdk-overlay-override.less
+++ b/packages/bits/src/styles/cdk-overlay-override.less
@@ -2,9 +2,4 @@
 @import (reference) "./nui-framework-variables.less";
 .nui .cdk-overlay-container {
     z-index: @zindex-tooltip;
-
-    .translate-right {
-        transform: translate(-50%, 0);
-        transition: none;
-    }
 }


### PR DESCRIPTION
## Frontend Pull Request Description
When MenuComponent is placed on the bottom right side of a viewport it may render a popup shifted incorrectly regarding the origin button leading to a situation where the popup is not fully visible in the viewport of the browser.

Details: https://github.com/solarwinds/nova/issues/692

## Checklist
- [x] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my code
- [x] I have updated [change log](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/CHANGELOG.md#L4)
- [x] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/DEFINITION_OF_DONE.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [x] New and existing unit tests pass locally and on CI with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Context
https://briantree.se/angular-cdk-overlay-tutorial-positioning/