### PR TITLE
Fix menu overlay position fallback

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [15.0.6] 2024-05-13
+
+### Bugfix
+
+-   `@nova-ui/bits` | Properly show _niuMenuComponent_ popup when menu button is located at the bottom right corner of the viewport.
+
 ## [12.0.43] 📅 20023-04-09
 
 ### Added

--- a/packages/bits/scripts/compile-demo-paths.js
+++ b/packages/bits/scripts/compile-demo-paths.js
@@ -24,7 +24,7 @@ const getFilesRecursively = (directory) => {
 getFilesRecursively(dir);
 
 const trimmedFiles = files.map((filePath) =>
-    filePath.replaceAll("\\", "/").replace(dir, "")
+    filePath.replace(/\\/g, "/").replace(dir, "")
 );
 
 fs.writeFileSync(

--- a/packages/bits/src/lib/popup-adapter/popup-adapter.component.ts
+++ b/packages/bits/src/lib/popup-adapter/popup-adapter.component.ts
@@ -272,9 +272,8 @@ export class PopupComponent
         const bottomRight: ConnectedPosition = {
             originX: "end",
             originY: "bottom",
-            overlayX: "center",
+            overlayX: "end",
             overlayY: "top",
-            panelClass: "translate-right",
         };
         const bottomLeft: ConnectedPosition = {
             originX: "end",
@@ -285,9 +284,8 @@ export class PopupComponent
         const rightTop: ConnectedPosition = {
             originX: "end",
             originY: "top",
-            overlayX: "center",
+            overlayX: "end",
             overlayY: "bottom",
-            panelClass: "translate-right",
         };
 
         if (this.directionTop && this.directionRight) {

--- a/packages/bits/src/styles/cdk-overlay-override.less
+++ b/packages/bits/src/styles/cdk-overlay-override.less
@@ -2,9 +2,4 @@
 @import (reference) "./nui-framework-variables.less";
 .nui .cdk-overlay-container {
     z-index: @zindex-tooltip;
-
-    .translate-right {
-        transform: translate(-50%, 0);
-        transition: none;
-    }
 }


### PR DESCRIPTION
Update changelog and fix issue with `replaceAll` method Fix the issue with overlay positioning

Details: https://briantree.se/angular-cdk-overlay-tutorial-positioning/

## Frontend Pull Request Description

<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/CHANGELOG.md#L4)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
