### PR TITLE
bugfix/OO-31247 - Add Missing Empty to ListWidgetComponent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+## [15.0.8] 2024-06-03
+
+### Bugfix
+
+- `@nova-ui/dashboards` | Added missing empty image for _nuiListWidgetComponent_ with no data.
+
 ## [15.0.6] 2024-05-13
 
 ### Bugfix
 
 -   `@nova-ui/bits` | Properly show _niuMenuComponent_ popup when menu button is located at the bottom right corner of the viewport.
 
-## [12.0.43] 📅 20023-04-09
+## [12.0.43] 📅 2023-04-09
 
 ### Added
 

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.html
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.html
@@ -1,7 +1,8 @@
 <nui-repeat
     *ngIf="shouldDisplayRepeat(); else empty"
     [itemsSource]="data"
-    [repeatItemTemplateRef]="repeatItemTemplate">
+    [repeatItemTemplateRef]="repeatItemTemplate"
+>
 </nui-repeat>
 
 <ng-template #empty>

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.html
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.html
@@ -1,5 +1,14 @@
-<nui-repeat [itemsSource]="data" [repeatItemTemplateRef]="repeatItemTemplate">
+<nui-repeat
+    *ngIf="shouldDisplayRepeat(); else empty"
+    [itemsSource]="data"
+    [repeatItemTemplateRef]="repeatItemTemplate">
 </nui-repeat>
+
+<ng-template #empty>
+    <div class="empty">
+        <nui-image image="no-data-to-show"></nui-image>
+    </div>
+</ng-template>
 
 <ng-template #repeatItemTemplate let-item="item">
     <ng-container

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.less
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.less
@@ -1,3 +1,7 @@
+:host {
+    height: 100%;
+}
+
 .empty {
     height: 100%;
     display: grid;

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.less
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.less
@@ -1,0 +1,5 @@
+.empty {
+    height: 100%;
+    display: grid;
+    place-content: center;
+}

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.less
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.less
@@ -1,5 +1,6 @@
 :host {
     height: 100%;
+    overflow: auto;
 }
 
 .empty {

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.ts
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.ts
@@ -47,7 +47,6 @@ const RESIZE_DEBOUNCE_TIME = 10;
     selector: "nui-list-widget",
     templateUrl: "./list-widget.component.html",
     styleUrls: ["./list-widget.component.less"],
-    host: { style: "overflow: scroll" },
 })
 export class ListWidgetComponent
     implements OnDestroy, OnInit, IHasChangeDetector, OnChanges

--- a/packages/dashboards/src/lib/components/list-widget/list-widget.component.ts
+++ b/packages/dashboards/src/lib/components/list-widget/list-widget.component.ts
@@ -100,6 +100,10 @@ export class ListWidgetComponent
         };
     }
 
+    public shouldDisplayRepeat(): boolean {
+        return (this.data?.length ?? 0) > 0;
+    }
+
     private calcItemProps(item: any) {
         if (!this.configuration) {
             return item;


### PR DESCRIPTION
## Frontend Pull Request Description

`nui-list-widget` was missing an empty state image.

## Checklist

- [x] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my code
- [x] I have updated [change log](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/CHANGELOG.md#L4)
- [x] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/DEFINITION_OF_DONE.md)
- [x] My changes generate no new lint warnings

## Screenshots (if applicable)

Before:
![image](https://github.com/solarwinds/nova/assets/97229167/be4befd2-70bb-4814-a023-c57926d2680e)
![image](https://github.com/solarwinds/nova/assets/97229167/73ab7b8e-5dee-4689-86bb-0922aa93b71b)
![image](https://github.com/solarwinds/nova/assets/97229167/4a29e6c3-4c9e-4662-b544-d2dafd25e8c4)

After:
![image](https://github.com/solarwinds/nova/assets/97229167/fe5b7da7-9014-4d20-9300-fddcf3aca55c)
![image](https://github.com/solarwinds/nova/assets/97229167/fc02f027-0055-4eba-b4fe-29e3943184e9)
![image](https://github.com/solarwinds/nova/assets/97229167/4084c69b-b816-4ce9-9329-441436ad03bf)

