### PR TITLE
refactor: added new header component for nui accordion

### DIFF
--- a/packages/dashboards/examples/src/components/docs/tutorials/customization/configurator-section/custom-configurator-section/custom-configurator-section.example.component.ts
+++ b/packages/dashboards/examples/src/components/docs/tutorials/customization/configurator-section/custom-configurator-section/custom-configurator-section.example.component.ts
@@ -76,7 +76,9 @@ import {
         >
             <nui-widget-editor-accordion-header
                 [subtitle]="subtitle$ | async"
-                [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
+                [headerIcon]="
+                    form | nuiFormHeaderIconPipe : 'widget_list' | async
+                "
             >
                 Description
             </nui-widget-editor-accordion-header>

--- a/packages/dashboards/examples/src/components/docs/tutorials/customization/configurator-section/custom-configurator-section/custom-configurator-section.example.component.ts
+++ b/packages/dashboards/examples/src/components/docs/tutorials/customization/configurator-section/custom-configurator-section/custom-configurator-section.example.component.ts
@@ -74,20 +74,12 @@ import {
             [formGroup]="form"
             [state]="form | nuiWidgetEditorAccordionFormState | async"
         >
-            <div accordionHeader class="d-flex align-items-center px-4 py-2">
-                <nui-icon
-                    class="align-self-start pt-2"
-                    [icon]="
-                        form | nuiFormHeaderIconPipe : 'widget_list' | async
-                    "
-                ></nui-icon>
-                <div class="d-flex flex-column ml-4 pt-1">
-                    <span class="nui-text-label" i18n>Description</span>
-                    <div class="nui-text-secondary" [title]="subtitle$ | async">
-                        {{ subtitle$ | async }}
-                    </div>
-                </div>
-            </div>
+            <nui-widget-editor-accordion-header
+                [subtitle]="subtitle$ | async"
+                [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
+            >
+                Description
+            </nui-widget-editor-accordion-header>
             <div class="kpi-description-configuration__accordion-content">
                 <div class="mb-4">
                     <nui-form-field

--- a/packages/dashboards/examples/src/components/docs/tutorials/customization/configurator-section/custom-configurator-section/custom-configurator-section.example.component.ts
+++ b/packages/dashboards/examples/src/components/docs/tutorials/customization/configurator-section/custom-configurator-section/custom-configurator-section.example.component.ts
@@ -79,9 +79,8 @@ import {
                 [headerIcon]="
                     form | nuiFormHeaderIconPipe : 'widget_list' | async
                 "
-            >
-                Description
-            </nui-widget-editor-accordion-header>
+                title="Description"
+            />
             <div class="kpi-description-configuration__accordion-content">
                 <div class="mb-4">
                     <nui-form-field

--- a/packages/dashboards/examples/src/components/docs/tutorials/customization/widget/custom-widget.component.ts
+++ b/packages/dashboards/examples/src/components/docs/tutorials/customization/widget/custom-widget.component.ts
@@ -105,6 +105,7 @@ export class CustomWidgetBodyContentComponent implements IHasChangeDetector {
             [state]="form | nuiWidgetEditorAccordionFormState | async"
         >
             <!-- The accordionHeader attribute lets the accordion component know which element to use as its header -->
+            <!-- There is also a pre-defined custom component <nui-widget-editor-accordion-header> that can be used instead -->
             <div accordionHeader class="d-flex align-items-center pl-4 py-2">
                 <!-- nuiFormHeaderIconPipe detects errors on the form and replaces the regular icon with an error icon if necessary -->
                 <nui-icon

--- a/packages/dashboards/examples/src/components/prototypes/components/data-source-configuration/proportional-ds-config.component.html
+++ b/packages/dashboards/examples/src/components/prototypes/components/data-source-configuration/proportional-ds-config.component.html
@@ -2,21 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center pl-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'database' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt1">
-            <span class="nui-text-label" i18n>Data Source</span>
-            <div
-                class="nui-text-secondary"
-                [title]="form.get('providerId')?.value"
-            >
-                {{ form.get("providerId")?.value }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'database' | async"
+        [subtitle]="form.get('providerId')?.value"
+    >
+        Data Source
+    </nui-widget-editor-accordion-header>
     <div class="datasource-configuration__accordion-content">
         <div class="mb-4">
             <nui-form-field

--- a/packages/dashboards/examples/src/components/prototypes/components/data-source-configuration/proportional-ds-config.component.html
+++ b/packages/dashboards/examples/src/components/prototypes/components/data-source-configuration/proportional-ds-config.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'database' | async"
         [subtitle]="form.get('providerId')?.value"
-    >
-        Data Source
-    </nui-widget-editor-accordion-header>
+        title="Data Source"
+    />
     <div class="datasource-configuration__accordion-content">
         <div class="mb-4">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/public-api.ts
+++ b/packages/dashboards/src/lib/configurator/components/public-api.ts
@@ -41,5 +41,6 @@ export * from "./widget-cloner/widget-cloner.component";
 export * from "./widget-configurator-section/widget-configurator-section.component";
 export * from "./widget-editor/widget-editor.component";
 export * from "./widget-editor-accordion/widget-editor-accordion.component";
+export * from "./widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component";
 export * from "./color-picker/color-picker.component";
 export * from "./drop-area/drop-area.component";

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.html
@@ -1,6 +1,6 @@
 <!-- This component can be used instead of specifying a custom template with accordionHeader attribute -->
 <!-- You can use it the same way (without accordionHeader attribute), it will get automatically assigned to the header of the accordion -->
-<div class="nui-widget-editor-accordion-header d-flex align-items-center px-4 py-2">
+<div class="d-flex align-items-center px-4 py-2">
     <nui-icon
         class="align-self-start pt-2"
         *ngIf="headerIcon"

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.html
@@ -1,0 +1,18 @@
+<!-- This component can be used instead of specifying a custom template with accordionHeader attribute -->
+<!-- You can use it the same way (without accordionHeader attribute), it will get automatically assigned to the header of the accordion -->
+<div class="nui-widget-editor-accordion-header d-flex align-items-center px-4 py-2">
+    <nui-icon
+        class="align-self-start pt-2"
+        *ngIf="headerIcon"
+        [icon]="headerIcon"
+        [iconColor]="iconColor"
+    ></nui-icon>
+    <div class="d-flex flex-column ml-4 pt-1">
+        <span class="nui-text-label" i18n>
+            <ng-content></ng-content>
+        </span>
+        <div class="nui-text-secondary" [title]="subtitle">
+            {{ subtitle }}
+        </div>
+    </div>
+</div>

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.html
@@ -9,7 +9,7 @@
     ></nui-icon>
     <div class="d-flex flex-column ml-4 pt-1">
         <span class="nui-text-label" i18n>
-            <ng-content></ng-content>
+            {{ title }}
         </span>
         <div class="nui-text-secondary" [title]="subtitle">
             {{ subtitle }}

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
@@ -9,4 +9,5 @@ export class WidgetEditorAccordionHeaderComponent {
     @Input() public headerIcon?: string;
     @Input() public iconColor: string = "gray";
     @Input() public subtitle: string = "";
+    @Input() public title: string = "";
 }

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
@@ -7,7 +7,7 @@ import { Component, Input } from "@angular/core";
 })
 export class WidgetEditorAccordionHeaderComponent {
     @Input() public headerIcon?: string;
-    @Input() public iconColor: string = "gray";
+    @Input() public iconColor?: string;
     @Input() public subtitle: string = "";
     @Input() public title: string = "";
 }

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
@@ -1,9 +1,9 @@
 import { Component, Input } from "@angular/core";
 
 @Component({
-  selector: "nui-widget-editor-accordion-header",
-  templateUrl: "./widget-editor-accordion-header.component.html",
-  styleUrls: [],
+    selector: "nui-widget-editor-accordion-header",
+    templateUrl: "./widget-editor-accordion-header.component.html",
+    styleUrls: [],
 })
 export class WidgetEditorAccordionHeaderComponent {
     @Input() public headerIcon?: string;

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from "@angular/core";
+
+@Component({
+  selector: "nui-widget-editor-accordion-header",
+  templateUrl: "./widget-editor-accordion-header.component.html",
+  styleUrls: [],
+})
+export class WidgetEditorAccordionHeaderComponent {
+    @Input() public headerIcon?: string;
+    @Input() public iconColor: string = "gray";
+    @Input() public subtitle: string = "";
+}

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.html
@@ -6,7 +6,7 @@
             [class.error-state]="state === 'critical'"
             [class.warning-state]="state === 'warning'"
         >
-            <ng-content select="[accordionHeader]"></ng-content>
+            <ng-content select="[accordionHeader], nui-widget-editor-accordion-header"></ng-content>
             <nui-icon
                 *ngIf="showOpenStateIcon"
                 class="nui-widget-editor-accordion__edit-icon"

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.html
@@ -6,7 +6,9 @@
             [class.error-state]="state === 'critical'"
             [class.warning-state]="state === 'warning'"
         >
-            <ng-content select="[accordionHeader], nui-widget-editor-accordion-header"></ng-content>
+            <ng-content
+                select="[accordionHeader], nui-widget-editor-accordion-header"
+            ></ng-content>
             <nui-icon
                 *ngIf="showOpenStateIcon"
                 class="nui-widget-editor-accordion__edit-icon"

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.less
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.less
@@ -37,7 +37,7 @@
             .setCssVariable(border-top-color, nui-color-line-default);
             min-height: 50px;
 
-            [accordionheader] {
+            .nui-widget-editor-accordion-header, [accordionheader] {
                 overflow: hidden;
 
                 & > div {

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.less
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.less
@@ -37,7 +37,8 @@
             .setCssVariable(border-top-color, nui-color-line-default);
             min-height: 50px;
 
-            nui-widget-editor-accordion-header, [accordionheader] {
+            nui-widget-editor-accordion-header,
+            [accordionheader] {
                 overflow: hidden;
 
                 & > div {

--- a/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.less
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor-accordion/widget-editor-accordion.component.less
@@ -37,7 +37,7 @@
             .setCssVariable(border-top-color, nui-color-line-default);
             min-height: 50px;
 
-            .nui-widget-editor-accordion-header, [accordionheader] {
+            nui-widget-editor-accordion-header, [accordionheader] {
                 overflow: hidden;
 
                 & > div {

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/background-color-rules-configuration/background-color-rules-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/background-color-rules-configuration/background-color-rules-configuration.component.html
@@ -2,18 +2,12 @@
     [formGroup]="formLocal"
     [state]="formLocal | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="formLocal | nuiFormHeaderIconPipe : 'color' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Background color rules</span>
-            <div class="nui-text-secondary" [title]="getColorRulesSubtitle()">
-                {{ getColorRulesSubtitle() }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="formLocal | nuiFormHeaderIconPipe : 'color' | async"
+        [subtitle]="getColorRulesSubtitle()"
+    >
+        Background color rules
+    </nui-widget-editor-accordion-header>
     <div class="kpi-color-rules-configuration__accordion-content">
         <div class="mb-4">
             <p class="mb-3">

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/background-color-rules-configuration/background-color-rules-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/background-color-rules-configuration/background-color-rules-configuration.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="formLocal | nuiFormHeaderIconPipe : 'color' | async"
         [subtitle]="getColorRulesSubtitle()"
-    >
-        Background color rules
-    </nui-widget-editor-accordion-header>
+        title="Background color rules"
+    />
     <div class="kpi-color-rules-configuration__accordion-content">
         <div class="mb-4">
             <p class="mb-3">

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration-v2/data-source-configuration-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration-v2/data-source-configuration-v2.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'database' | async"
         [subtitle]="form.get('dataSource')?.value?.label"
-    >
-        Timeseries metadata
-    </nui-widget-editor-accordion-header>
+        title="Data Source"
+    />
     <div class="datasource-configuration__accordion-content">
         <nui-form-field [control]="form.get('dataSource')">
             <nui-select-v2

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration-v2/data-source-configuration-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration-v2/data-source-configuration-v2.component.html
@@ -2,21 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center pl-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'database' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt1">
-            <span class="nui-text-label" i18n>Data Source</span>
-            <div
-                class="nui-text-secondary"
-                [title]="form.get('dataSource')?.value?.label"
-            >
-                {{ form.get("dataSource")?.value?.label }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'database' | async"
+        [subtitle]="form.get('dataSource')?.value?.label"
+    >
+        Timeseries metadata
+    </nui-widget-editor-accordion-header>
     <div class="datasource-configuration__accordion-content">
         <nui-form-field [control]="form.get('dataSource')">
             <nui-select-v2

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration/data-source-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration/data-source-configuration.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'database' | async"
         [subtitle]="form.get('providerId')?.value"
-    >
-        Data Source
-    </nui-widget-editor-accordion-header>
+        title="Data Source"
+    />
     <div class="datasource-configuration__accordion-content">
         <nui-form-field
             caption="Select Data Source"

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration/data-source-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/data-source-configuration/data-source-configuration.component.html
@@ -2,21 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center pl-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'database' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt1">
-            <span class="nui-text-label" i18n>Data Source</span>
-            <div
-                class="nui-text-secondary"
-                [title]="form.get('providerId')?.value"
-            >
-                {{ form.get("providerId")?.value }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'database' | async"
+        [subtitle]="form.get('providerId')?.value"
+    >
+        Data Source
+    </nui-widget-editor-accordion-header>
     <div class="datasource-configuration__accordion-content">
         <nui-form-field
             caption="Select Data Source"

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/thresholds-configuration/thresholds-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/thresholds-configuration/thresholds-configuration.component.html
@@ -2,23 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'thresholds' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Thresholds</span>
-            <div
-                class="nui-text-secondary"
-                [title]="
-                    getThresholdsSubtitle(form.get('showThresholds')?.value)
-                "
-            >
-                {{ getThresholdsSubtitle(form.get("showThresholds")?.value) }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'thresholds' | async"
+        [subtitle]="getThresholdsSubtitle(form.get('showThresholds')?.value)"
+    >
+        Thresholds
+    </nui-widget-editor-accordion-header>
     <div class="kpi-thresholds-configuration__accordion-content">
         <nui-form-field
             [control]="form.get('showThresholds')"

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/thresholds-configuration/thresholds-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/thresholds-configuration/thresholds-configuration.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'thresholds' | async"
         [subtitle]="getThresholdsSubtitle(form.get('showThresholds')?.value)"
-    >
-        Thresholds
-    </nui-widget-editor-accordion-header>
+        title="Thresholds"
+    />
     <div class="kpi-thresholds-configuration__accordion-content">
         <nui-form-field
             [control]="form.get('showThresholds')"

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/timeseries-metadata-configuration/timeseries-metadata-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/timeseries-metadata-configuration/timeseries-metadata-configuration.component.html
@@ -6,9 +6,8 @@
         [headerIcon]="form | nuiFormHeaderIconPipe : 'edit' | async"
         [iconColor]="form | nuiFormHeaderIconPipe : 'gray' : '' | async"
         [subtitle]="getSecondaryText()"
-    >
-        Timeseries metadata
-    </nui-widget-editor-accordion-header>
+        title="Timeseries metadata"
+    />
     <div class="timeseries-metadata-configuration__accordion-content">
         <div class="mb-4">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/timeseries-metadata-configuration/timeseries-metadata-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/timeseries-metadata-configuration/timeseries-metadata-configuration.component.html
@@ -2,19 +2,13 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'edit' | async"
-            [iconColor]="form | nuiFormHeaderIconPipe : 'gray' : '' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Timeseries metadata</span>
-            <div class="nui-text-secondary" [title]="getSecondaryText()">
-                {{ getSecondaryText() }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'edit' | async"
+        [iconColor]="form | nuiFormHeaderIconPipe : 'gray' : '' | async"
+        [subtitle]="getSecondaryText()"
+    >
+        Timeseries metadata
+    </nui-widget-editor-accordion-header>
     <div class="timeseries-metadata-configuration__accordion-content">
         <div class="mb-4">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/timeseries-metadata-configuration/timeseries-metadata-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/timeseries-metadata-configuration/timeseries-metadata-configuration.component.html
@@ -4,10 +4,11 @@
 >
     <div accordionHeader class="d-flex align-items-center px-4 py-2">
         <nui-icon
+            class="align-self-start pt-2"
             [icon]="form | nuiFormHeaderIconPipe : 'edit' | async"
             [iconColor]="form | nuiFormHeaderIconPipe : 'gray' : '' | async"
         ></nui-icon>
-        <div class="d-flex flex-column ml-4">
+        <div class="d-flex flex-column ml-4 pt-1">
             <span class="nui-text-label" i18n>Timeseries metadata</span>
             <div class="nui-text-secondary" [title]="getSecondaryText()">
                 {{ getSecondaryText() }}

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/title-and-description-configuration/title-and-description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/title-and-description-configuration/title-and-description-configuration.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
         [subtitle]="getSecondaryText()"
-    >
-        Title and Description
-    </nui-widget-editor-accordion-header>
+        title="Title and Description"
+    />
     <div class="title-and-description-configuration__accordion-content">
         <div class="mb-4">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/title-and-description-configuration/title-and-description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/configurator-items/title-and-description-configuration/title-and-description-configuration.component.html
@@ -2,18 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Title and Description</span>
-            <div [title]="getSecondaryText()" class="nui-text-secondary">
-                {{ getSecondaryText() }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
+        [subtitle]="getSecondaryText()"
+    >
+        Title and Description
+    </nui-widget-editor-accordion-header>
     <div class="title-and-description-configuration__accordion-content">
         <div class="mb-4">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/drilldown/grouping-configuration/grouping-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/drilldown/grouping-configuration/grouping-configuration.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="'tag'"
         [subtitle]="getSubtitle()"
-    >
-        Grouping
-    </nui-widget-editor-accordion-header>
+        title="Grouping"
+    />
     <div
         class="grouping-configuration__accordion-content"
         formArrayName="groupBy"

--- a/packages/dashboards/src/lib/configurator/components/widgets/drilldown/grouping-configuration/grouping-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/drilldown/grouping-configuration/grouping-configuration.component.html
@@ -2,19 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="'tag'"
-            iconColor="gray"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Grouping</span>
-            <div class="nui-text-secondary" [title]="getSubtitle()">
-                {{ getSubtitle() }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="'tag'"
+        [subtitle]="getSubtitle()"
+    >
+        Grouping
+    </nui-widget-editor-accordion-header>
     <div
         class="grouping-configuration__accordion-content"
         formArrayName="groupBy"

--- a/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor-v2/proportional-chart-options-editor-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor-v2/proportional-chart-options-editor-v2.component.html
@@ -2,18 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'widget_pie-chart' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Chart Options</span>
-            <div class="nui-text-secondary" [title]="chartTitle">
-                {{ chartTitle }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_pie-chart' | async"
+        [subtitle]="chartTitle"
+    >
+        Chart Optionss
+    </nui-widget-editor-accordion-header>
     <div
         class="proportional-widget-chart-options-configuration__accordion-content"
     >

--- a/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor-v2/proportional-chart-options-editor-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor-v2/proportional-chart-options-editor-v2.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_pie-chart' | async"
         [subtitle]="chartTitle"
-    >
-        Chart Optionss
-    </nui-widget-editor-accordion-header>
+        title="Chart Options"
+    />
     <div
         class="proportional-widget-chart-options-configuration__accordion-content"
     >

--- a/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor/proportional-chart-options-editor.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor/proportional-chart-options-editor.component.html
@@ -2,18 +2,12 @@
     [formGroup]="form"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            [icon]="form | nuiFormHeaderIconPipe : 'widget_pie-chart' | async"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Chart Options</span>
-            <div class="nui-text-secondary" [title]="chartTitle">
-                {{ chartTitle }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_pie-chart' | async"
+        [subtitle]="chartTitle"
+    >
+        Chart options
+    </nui-widget-editor-accordion-header>
     <div
         class="proportional-widget-chart-options-configuration__accordion-content"
     >

--- a/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor/proportional-chart-options-editor.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/proportional/chart-options-editor/proportional-chart-options-editor.component.html
@@ -5,9 +5,8 @@
     <nui-widget-editor-accordion-header
         [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_pie-chart' | async"
         [subtitle]="chartTitle"
-    >
-        Chart options
-    </nui-widget-editor-accordion-header>
+        title="Chart options"
+    />
     <div
         class="proportional-widget-chart-options-configuration__accordion-content"
     >

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/description-configuration/description-configuration-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/description-configuration/description-configuration-v2.component.html
@@ -2,21 +2,12 @@
     <nui-widget-editor-accordion
         [state]="form | nuiWidgetEditorAccordionFormState | async"
     >
-        <div accordionHeader class="d-flex align-items-center px-4 py-2">
-            <nui-icon
-                class="align-self-start pt-2"
-                [icon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
-            ></nui-icon>
-            <div class="d-flex flex-column ml-4 w-100 overflow-hidden pt-1">
-                <span class="nui-text-label" i18n>Description</span>
-                <div
-                    class="nui-text-secondary nui-text-ellipsis"
-                    [title]="form.controls['label'].value"
-                >
-                    {{ form.controls["label"].value }}
-                </div>
-            </div>
-        </div>
+        <nui-widget-editor-accordion-header
+            [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
+            [subtitle]="form.controls['label'].value"
+        >
+            Description
+        </nui-widget-editor-accordion-header>
         <div class="description-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/description-configuration/description-configuration-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/description-configuration/description-configuration-v2.component.html
@@ -5,9 +5,8 @@
         <nui-widget-editor-accordion-header
             [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
             [subtitle]="form.controls['label'].value"
-        >
-            Description
-        </nui-widget-editor-accordion-header>
+            title="Description"
+        />
         <div class="description-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/presentation-configuration/presentation-configuration-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/presentation-configuration/presentation-configuration-v2.component.html
@@ -2,18 +2,12 @@
     <nui-widget-editor-accordion
         [state]="form | nuiWidgetEditorAccordionFormState | async"
     >
-        <div accordionHeader class="d-flex align-items-center px-4 py-2">
-            <nui-icon
-                class="align-self-start pt-2"
-                [icon]="form | nuiFormHeaderIconPipe : 'customize' | async"
-            ></nui-icon>
-            <div class="d-flex flex-column ml-4 pt-1">
-                <span class="nui-text-label" i18n>Property and formatting</span>
-                <div class="nui-text-secondary" [title]="subtitleText">
-                    {{ subtitleText }}
-                </div>
-            </div>
-        </div>
+        <nui-widget-editor-accordion-header
+            [headerIcon]="form | nuiFormHeaderIconPipe : 'customize' | async"
+            [subtitle]="subtitleText"
+        >
+            Property and formatting
+        </nui-widget-editor-accordion-header>
         <div class="presentation-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/presentation-configuration/presentation-configuration-v2.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor-v2/column-configuration/presentation-configuration/presentation-configuration-v2.component.html
@@ -5,9 +5,8 @@
         <nui-widget-editor-accordion-header
             [headerIcon]="form | nuiFormHeaderIconPipe : 'customize' | async"
             [subtitle]="subtitleText"
-        >
-            Property and formatting
-        </nui-widget-editor-accordion-header>
+            title="Property and formatting"
+        />
         <div class="presentation-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/description-configuration/description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/description-configuration/description-configuration.component.html
@@ -2,21 +2,12 @@
     <nui-widget-editor-accordion
         [state]="form | nuiWidgetEditorAccordionFormState | async"
     >
-        <div accordionHeader class="d-flex align-items-center px-4 py-2">
-            <nui-icon
-                class="align-self-start pt-2"
-                [icon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
-            ></nui-icon>
-            <div class="d-flex flex-column ml-4 w-100 overflow-hidden pt-1">
-                <span class="nui-text-label" i18n>Description</span>
-                <div
-                    class="nui-text-secondary nui-text-ellipsis"
-                    [title]="form.controls['label'].value"
-                >
-                    {{ form.controls["label"].value }}
-                </div>
-            </div>
-        </div>
+        <nui-widget-editor-accordion-header
+            [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
+            [subtitle]="form.controls['label'].value"
+        >
+            Description
+        </nui-widget-editor-accordion-header>
         <div class="description-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/description-configuration/description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/description-configuration/description-configuration.component.html
@@ -5,9 +5,8 @@
         <nui-widget-editor-accordion-header
             [headerIcon]="form | nuiFormHeaderIconPipe : 'widget_list' | async"
             [subtitle]="form.controls['label'].value"
-        >
-            Description
-        </nui-widget-editor-accordion-header>
+            title="Description"
+        />
         <div class="description-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/presentation-configuration/presentation-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/presentation-configuration/presentation-configuration.component.html
@@ -2,18 +2,12 @@
     <nui-widget-editor-accordion
         [state]="form | nuiWidgetEditorAccordionFormState | async"
     >
-        <div accordionHeader class="d-flex align-items-center px-4 py-2">
-            <nui-icon
-                class="align-self-start pt-2"
-                [icon]="form | nuiFormHeaderIconPipe : 'customize' | async"
-            ></nui-icon>
-            <div class="d-flex flex-column ml-4 pt-1">
-                <span class="nui-text-label" i18n>Property and formatting</span>
-                <div class="nui-text-secondary" [title]="subtitleText">
-                    {{ subtitleText }}
-                </div>
-            </div>
-        </div>
+        <nui-widget-editor-accordion-header
+            [headerIcon]="form | nuiFormHeaderIconPipe : 'customize' | async"
+            [subtitle]="subtitleText"
+        >
+            Property and formatting
+        </nui-widget-editor-accordion-header>
         <div class="presentation-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/presentation-configuration/presentation-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/columns-editor/column-configuration/presentation-configuration/presentation-configuration.component.html
@@ -5,9 +5,8 @@
         <nui-widget-editor-accordion-header
             [headerIcon]="form | nuiFormHeaderIconPipe : 'customize' | async"
             [subtitle]="subtitleText"
-        >
-            Property and formatting
-        </nui-widget-editor-accordion-header>
+            title="Property and formatting"
+        />
         <div class="presentation-configuration__accordion-content">
             <div class="mb-4">
                 <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/filters-editor/table-filters-editor.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/filters-editor/table-filters-editor.component.html
@@ -2,9 +2,8 @@
     <nui-widget-editor-accordion-header
         headerIcon="widget_pie-chart"
         [subtitle]="selectedSortByValue + selectedSortOrderValue"
-    >
-        Sorting
-    </nui-widget-editor-accordion-header>
+        title="Sorting"
+    />
     <div class="table-filters-configuration__accordion-content">
         <div formGroupName="sorterConfiguration" class="d-flex align-items-end">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/filters-editor/table-filters-editor.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/filters-editor/table-filters-editor.component.html
@@ -1,19 +1,10 @@
 <nui-widget-editor-accordion [formGroup]="form">
-    <div accordionHeader class="d-flex align-items-center px-4 py-2">
-        <nui-icon
-            class="align-self-start pt-2"
-            icon="widget_pie-chart"
-        ></nui-icon>
-        <div class="d-flex flex-column ml-4 pt-1">
-            <span class="nui-text-label" i18n>Sorting</span>
-            <div
-                class="nui-text-secondary"
-                [title]="selectedSortByValue + selectedSortOrderValue"
-            >
-                {{ selectedSortByValue }}{{ selectedSortOrderValue }}
-            </div>
-        </div>
-    </div>
+    <nui-widget-editor-accordion-header
+        headerIcon="widget_pie-chart"
+        [subtitle]="selectedSortByValue + selectedSortOrderValue"
+    >
+        Sorting
+    </nui-widget-editor-accordion-header>
     <div class="table-filters-configuration__accordion-content">
         <div formGroupName="sorterConfiguration" class="d-flex align-items-end">
             <nui-form-field

--- a/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-description-configuration/timeseries-tile-description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-description-configuration/timeseries-tile-description-configuration.component.html
@@ -3,11 +3,11 @@
         [state]="form.get('label') | nuiWidgetEditorAccordionFormState | async"
     >
         <nui-widget-editor-accordion-header
-            [headerIcon]="form.get('label') | nuiFormHeaderIconPipe : 'edit' | async"
+            [headerIcon]="
+                form.get('label') | nuiFormHeaderIconPipe : 'edit' | async
+            "
             [iconColor]="
-                    form.get('label')
-                        | nuiFormHeaderIconPipe : 'gray' : ''
-                        | async
+                form.get('label') | nuiFormHeaderIconPipe : 'gray' : '' | async
             "
             [subtitle]="form.get('label')?.value"
         >

--- a/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-description-configuration/timeseries-tile-description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-description-configuration/timeseries-tile-description-configuration.component.html
@@ -2,28 +2,17 @@
     <nui-widget-editor-accordion
         [state]="form.get('label') | nuiWidgetEditorAccordionFormState | async"
     >
-        <div accordionHeader class="d-flex align-items-center px-4 py-2">
-            <nui-icon
-                class="align-self-start pt-2"
-                [icon]="
-                    form.get('label') | nuiFormHeaderIconPipe : 'edit' | async
-                "
-                [iconColor]="
+        <nui-widget-editor-accordion-header
+            [headerIcon]="form.get('label') | nuiFormHeaderIconPipe : 'edit' | async"
+            [iconColor]="
                     form.get('label')
                         | nuiFormHeaderIconPipe : 'gray' : ''
                         | async
-                "
-            ></nui-icon>
-            <div class="d-flex flex-column ml-4 pt-1">
-                <span class="nui-text-label" i18n>Description</span>
-                <div
-                    class="nui-text-secondary"
-                    [title]="form.get('label')?.value"
-                >
-                    {{ form.get("label")?.value }}
-                </div>
-            </div>
-        </div>
+            "
+            [subtitle]="form.get('label')?.value"
+        >
+            Description
+        </nui-widget-editor-accordion-header>
         <div
             class="timeseries-tile-description-configuration__accordion-content"
         >

--- a/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-description-configuration/timeseries-tile-description-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-description-configuration/timeseries-tile-description-configuration.component.html
@@ -10,9 +10,8 @@
                 form.get('label') | nuiFormHeaderIconPipe : 'gray' : '' | async
             "
             [subtitle]="form.get('label')?.value"
-        >
-            Description
-        </nui-widget-editor-accordion-header>
+            title="Description"
+        />
         <div
             class="timeseries-tile-description-configuration__accordion-content"
         >

--- a/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-indicator-data-configuration/timeseries-tile-indicator-data-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-indicator-data-configuration/timeseries-tile-indicator-data-configuration.component.html
@@ -2,23 +2,12 @@
     <nui-widget-editor-accordion
         [state]="form.get('id') | nuiWidgetEditorAccordionFormState | async"
     >
-        <div accordionHeader class="d-flex align-items-center px-4 py-2">
-            <nui-icon
-                class="align-self-start pt-2"
-                [icon]="
-                    form.get('id') | nuiFormHeaderIconPipe : 'database' | async
-                "
-            ></nui-icon>
-            <div class="d-flex flex-column ml-4 pt-1">
-                <span class="nui-text-label" i18n>Indicator data</span>
-                <div
-                    class="nui-text-secondary"
-                    [title]="selectedSeries?.description"
-                >
-                    {{ selectedSeries?.description }}
-                </div>
-            </div>
-        </div>
+        <nui-widget-editor-accordion-header
+            [headerIcon]="form.get('id') | nuiFormHeaderIconPipe : 'database' | async"
+            [subtitle]="selectedSeries?.description"
+        >
+            Indicator data
+        </nui-widget-editor-accordion-header>
         <div class="timeseries-tile-data-configuration__accordion-content">
             <nui-form-field
                 caption="Series data"

--- a/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-indicator-data-configuration/timeseries-tile-indicator-data-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-indicator-data-configuration/timeseries-tile-indicator-data-configuration.component.html
@@ -7,9 +7,8 @@
                 form.get('id') | nuiFormHeaderIconPipe : 'database' | async
             "
             [subtitle]="selectedSeries?.description"
-        >
-            Indicator data
-        </nui-widget-editor-accordion-header>
+            title="Indicator data"
+        />
         <div class="timeseries-tile-data-configuration__accordion-content">
             <nui-form-field
                 caption="Series data"

--- a/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-indicator-data-configuration/timeseries-tile-indicator-data-configuration.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/timeseries/timeseries-tile-indicator-data-configuration/timeseries-tile-indicator-data-configuration.component.html
@@ -3,7 +3,9 @@
         [state]="form.get('id') | nuiWidgetEditorAccordionFormState | async"
     >
         <nui-widget-editor-accordion-header
-            [headerIcon]="form.get('id') | nuiFormHeaderIconPipe : 'database' | async"
+            [headerIcon]="
+                form.get('id') | nuiFormHeaderIconPipe : 'database' | async
+            "
             [subtitle]="selectedSeries?.description"
         >
             Indicator data

--- a/packages/dashboards/src/lib/configurator/configurator.module.ts
+++ b/packages/dashboards/src/lib/configurator/configurator.module.ts
@@ -81,6 +81,7 @@ import { PreviewPlaceholderComponent } from "./components/preview-placeholder/pr
 import { WidgetClonerComponent } from "./components/widget-cloner/widget-cloner.component";
 import { WidgetConfiguratorSectionCoordinatorService } from "./components/widget-configurator-section/widget-configurator-section-coordinator.service";
 import { WidgetConfiguratorSectionComponent } from "./components/widget-configurator-section/widget-configurator-section.component";
+import { WidgetEditorAccordionHeaderComponent } from "./components/widget-editor-accordion/widget-editor-accordion-header/widget-editor-accordion-header.component";
 import { WidgetEditorAccordionComponent } from "./components/widget-editor-accordion/widget-editor-accordion.component";
 import { WidgetEditorComponent } from "./components/widget-editor/widget-editor.component";
 import { BackgroundColorRulesConfigurationComponent } from "./components/widgets/configurator-items/background-color-rules-configuration/background-color-rules-configuration.component";
@@ -194,6 +195,7 @@ const exportedDeclarations = [
     DashwizComponent,
     DashwizStepComponent,
     WidgetEditorAccordionComponent,
+    WidgetEditorAccordionHeaderComponent,
     ItemsDynamicComponent,
     ColorPickerComponent,
     ConfiguratorHeadingComponent,


### PR DESCRIPTION
## Frontend Pull Request Description

Created a common component for accordion headers:
https://swicloud.atlassian.net/browse/NUI-6225

## Checklist

- [x] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/CHANGELOG.md#L4)
- [x] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/2415fa06f8242b9024beee04e2456055d31ab118/docs/DEFINITION_OF_DONE.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
