### PR TITLE
`AppendToBody` for toolbar to pass to its menu

### DIFF
--- a/packages/bits/src/lib/toolbar/toolbar.component.html
+++ b/packages/bits/src/lib/toolbar/toolbar.component.html
@@ -48,6 +48,7 @@
         <nui-menu
             displayStyle="action"
             #menuComponent
+            [appendToBody]="appendToBody"
             [title]="menuTitle"
             *ngIf="showMenu"
         >

--- a/packages/bits/src/lib/toolbar/toolbar.component.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.ts
@@ -98,6 +98,12 @@ export class ToolbarComponent implements AfterViewInit, OnDestroy {
     @Input()
     public noEmptyMessage: boolean = false;
 
+    /**
+     * Passed to the toolbar menu
+     */
+    @Input()
+    public appendToBody: boolean = false;
+
     @ViewChild("menuComponent") public menu: MenuComponent;
 
     @ViewChildren("toolbarButtons")


### PR DESCRIPTION
## Frontend Pull Request Description

Toolbar menu is forced to be appended to the toolbar, but its position is computed on the assumption that the toolbar is not placed under a `position: relative` parent. In short, the menu appear in wrong place. Appending it to the body fixes that.

## Checklist

- [x] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [x] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new lint warnings
- [x] New and existing unit tests pass locally and on CI with my changes
- [x] Any dependent changes have been merged and published in downstream modules
