### PR TITLE
fix: add aggregatedCount to stackedArea value calc

### DIFF
--- a/packages/dashboards/src/lib/components/timeseries-widget/chart-presets/xy-chart/xy-chart.component.ts
+++ b/packages/dashboards/src/lib/components/timeseries-widget/chart-presets/xy-chart/xy-chart.component.ts
@@ -479,8 +479,11 @@ export abstract class XYChartComponent
         ) {
             const submetricsCount = this.chartAssist.legendSeriesSet.length;
             const strVal = `${val ?? 0}`;
+            const aggregatedCount = legendSeries.aggregatedCount || 1;
+            const adjustedValue =
+                (parseFloat(strVal ?? "0") * submetricsCount) / aggregatedCount;
 
-            return `${parseFloat(strVal ?? "0") * submetricsCount} %`;
+            return `${+adjustedValue.toFixed(2)} %`;
         }
 
         return val;


### PR DESCRIPTION
## Frontend Pull Request Description

Fixes CPUMultiLoad metric chart with >= 10 CPUs in Performance Analysis.

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
TBD

## Additional Context (if necessary)
TBD