### PR TITLE
Fix the sets page sizes, Change expander section

### DIFF
--- a/packages/dashboards/src/lib/configurator/components/widgets/table/scrollType-editor/scroll-type-editor.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/scrollType-editor/scroll-type-editor.component.html
@@ -1,6 +1,5 @@
 <nui-widget-editor-accordion
     [formGroup]="form"
-    (openToggle)="accordionToggle($event)"
     [state]="form | nuiWidgetEditorAccordionFormState | async"
 >
     <nui-widget-editor-accordion-header
@@ -14,9 +13,9 @@
     >
         <div class="scroll-type-field d-flex align-items-end">
             <nui-form-field
+                [showOptionalText]="false"
                 caption="Scroll Type"
                 i18n-caption
-                [control]="form.controls['scrollType']"
             >
                 <nui-select-v2
                     placeholder="Select scroll type"
@@ -37,73 +36,70 @@
             </nui-form-field>
         </div>
         <div *ngIf="hasPaginator">
-            <nui-expander
-                i18n-header
-                header="Advanced Options"
-                (openChange)="changeExpanderState($event)"
-                [open]="isExpanderOpen"
-            >
-                <div class="expander-content">
-                    <div class="page-size-set-menu">
-                        <nui-menu
-                            title="Page size options set"
-                            [appendToBody]="true"
-                            i18n-title
-                        >
-                            <nui-menu-group header="Item Types" i18n-header>
-                                <nui-menu-option
-                                    *ngFor="let option of pageSizeSetOptions"
-                                    (actionDone)="onPageSizeSetChange(option)"
-                                    [checked]="option.checked"
-                                    i18n
-                                    >{{ option.value }}</nui-menu-option
-                                >
-                            </nui-menu-group>
-                        </nui-menu>
-                        <nui-validation-message
-                            [show]="displayPageSizeSetErrorMessage"
-                            i18n
-                        >
-                            Page size set is required
-                        </nui-validation-message>
-                    </div>
-
-                    <div
-                        *ngIf="pageSizeOptions.length > 0"
-                        class="d-flex align-items-end"
+            <div class="page-size-set-menu">
+                <nui-form-field
+                        class=""
+                    caption="Page size options set"
+                    i18n-caption
+                    [showOptionalText]="false"
+                >
+                    <nui-menu
+                        title="Select size options"
+                        [appendToBody]="true"
+                        i18n-title
                     >
-                        <nui-form-field
-                            caption="Default page size"
-                            i18n-caption
-                            [showOptionalText]="false"
-                            [control]="form.controls['pageSize']"
-                        >
-                            <nui-select-v2
-                                placeholder="Select page size"
-                                i18n-placeholder
-                                [popupViewportMargin]="
-                                    configuratorHeading.height$ | async
-                                "
-                                formControlName="pageSize"
-                                class="table-filters-configuration__accordion-content__sort-by-input"
-                            >
-                                <nui-select-v2-option
-                                    *ngFor="let option of pageSizeOptions"
-                                    [value]="option"
-                                >
-                                    {{ option }}
-                                </nui-select-v2-option>
-                            </nui-select-v2>
-                            <nui-validation-message
-                                [show]="displayPageSizeErrorMessage"
+                        <nui-menu-group header="Item Types" i18n-header>
+                            <nui-menu-option
+                                *ngFor="let option of pageSizeSetOptions"
+                                (actionDone)="onPageSizeSetChange(option)"
+                                [checked]="option.checked"
                                 i18n
-                            >
-                                Page size is required
-                            </nui-validation-message>
-                        </nui-form-field>
-                    </div>
-                </div>
-            </nui-expander>
+                                >{{ option.value }}
+                            </nui-menu-option>
+                        </nui-menu-group>
+                    </nui-menu>
+                    <nui-validation-message
+                        [show]="displayPageSizeSetErrorMessage"
+                        i18n
+                    >
+                        Page size set is required
+                    </nui-validation-message>
+                </nui-form-field>
+            </div>
+            <div
+                *ngIf="pageSizeOptions.length > 0"
+                class="d-flex align-items-end"
+            >
+                <nui-form-field
+                    caption="Default page size"
+                    i18n-caption
+                    [showOptionalText]="false"
+                    [control]="form.controls['pageSize']"
+                >
+                    <nui-select-v2
+                        placeholder="Select page size"
+                        i18n-placeholder
+                        [popupViewportMargin]="
+                            configuratorHeading.height$ | async
+                        "
+                        formControlName="pageSize"
+                        class="table-filters-configuration__accordion-content__sort-by-input"
+                    >
+                        <nui-select-v2-option
+                            *ngFor="let option of pageSizeOptions"
+                            [value]="option"
+                        >
+                            {{ option }}
+                        </nui-select-v2-option>
+                    </nui-select-v2>
+                    <nui-validation-message
+                        [show]="displayPageSizeErrorMessage"
+                        i18n
+                    >
+                        Page size is required
+                    </nui-validation-message>
+                </nui-form-field>
+            </div>
         </div>
     </div>
 </nui-widget-editor-accordion>

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/scrollType-editor/scroll-type-editor.component.less
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/scrollType-editor/scroll-type-editor.component.less
@@ -9,13 +9,9 @@
             margin-bottom: @nui-space-sm;
         }
 
-        .expander-content {
-            display: flex;
-
-            .page-size-set-menu {
-                margin-top: 26px;
-                margin-right: @nui-space-sm;
-            }
+        .page-size-set-menu {
+            margin-bottom: @nui-space-sm;
         }
+
     }
 }

--- a/packages/dashboards/src/lib/configurator/components/widgets/table/scrollType-editor/scroll-type-editor.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widgets/table/scrollType-editor/scroll-type-editor.component.ts
@@ -98,11 +98,10 @@ export class TableScrollTypeEditorComponent
 
     public ngOnChanges(changes: SimpleChanges): void {
         if (changes.scrollType) {
-            this.scrollTypeFormControl?.setValue(this.scrollType, {
+            this.scrollTypeFormControl?.setValue(this.scrollType ?? ScrollType.virtual, {
                 emitEvent: false,
             });
 
-            this.changeExpanderState(false);
             this.updateSubtitle();
             this.updateValidators();
         }
@@ -194,16 +193,8 @@ export class TableScrollTypeEditorComponent
         this.emitUpdatedSelectedOptions();
     }
 
-    public get hasPaginator() {
+    public get hasPaginator(): boolean {
         return this.scrollTypeFormControl?.value === ScrollType.paginator;
-    }
-
-    public accordionToggle(isOpened: boolean) {
-        this.changeExpanderState(false);
-    }
-
-    public changeExpanderState(isOpen: boolean) {
-        this.isExpanderOpen = isOpen;
     }
 
     private updateSubtitle(): void {
@@ -239,7 +230,7 @@ export class TableScrollTypeEditorComponent
 
         this.updateDefaultPageSizeOptions(filteredPageSizeSet);
         this.pageSizeSetFormControl?.setValue(filteredPageSizeSet, {
-            emitEvent: false,
+            emitEvent: true,
         });
     }
 


### PR DESCRIPTION
## Frontend Pull Request Description
Changed the table widget scroll type configurator. Fixed selection by default virtual scroll. Fixed the page size changes. 
<!-- Provide a brief summary of the changes made in the frontend project. -->
Changed UI selection mode for the scroll type paging. (Removed expander and leave section display)


## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/3664d12c-b806-4a8d-8e2d-259270d273aa)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)
https://swicloud.atlassian.net/browse/NUI-6251
<!-- Provide any additional context or information that might be useful for reviewers. -->
