### PR TITLE
remove warning because of the selector duplication

### DIFF
--- a/packages/dashboards/src/lib/configurator/components/formatters/donut-content-raw-formatter/donut-content-raw-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/donut-content-raw-formatter/donut-content-raw-formatter.component.ts
@@ -29,6 +29,7 @@ import { IProportionalWidgetConfig } from "../../../../components/public-api";
 import { IFormatterData } from "../types";
 
 @Component({
+    selector: "nui-donut-content-raw-formatter",
     template: `<ng-container>
         <nui-icon
             *ngIf="config?.chartDonutContentIcon"

--- a/packages/dashboards/src/lib/configurator/components/formatters/donut-content-sum-formatter/donut-content-sum-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/donut-content-sum-formatter/donut-content-sum-formatter.component.ts
@@ -24,6 +24,7 @@ import sumBy from "lodash/sumBy";
 import { IFormatterData } from "../types";
 
 @Component({
+    selector: "nui-dashboards-donut-content-sum-formatter",
     template: `<ng-container
         ><div class="nui-text-page">{{ this.sum }}</div></ng-container
     >`,

--- a/packages/dashboards/src/lib/configurator/components/formatters/icon-formatter/icon-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/icon-formatter/icon-formatter.component.ts
@@ -26,6 +26,7 @@ import { IHasChangeDetector } from "../../../../types";
 import { IFormatterData } from "../types";
 
 @Component({
+    selector: "nui-dashboards-icon-formatter",
     template: `
         <div
             *ngIf="isValid"

--- a/packages/dashboards/src/lib/configurator/components/formatters/link-formatter/link-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/link-formatter/link-formatter.component.ts
@@ -30,6 +30,7 @@ import { IHasChangeDetector } from "../../../../types";
 import { ILinkFormatterData } from "../types";
 
 @Component({
+    // selector: "nui-dashboards-link-formatter",
     template: `<div class="link-formatter-container">
         <a
             *ngIf="isValid"

--- a/packages/dashboards/src/lib/configurator/components/formatters/percentage-formatter/percentage-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/percentage-formatter/percentage-formatter.component.ts
@@ -23,7 +23,8 @@ import { Component } from "@angular/core";
 import { RawFormatterComponent } from "../raw-formatter/raw-formatter.component";
 
 @Component({
-    template: ` <ng-container> {{ data?.value }}% </ng-container>`,
+    selector: "nui-dashboards-percentage-formatter",
+    template: `<ng-container> {{ data?.value }}% </ng-container>`,
 })
 export class PercentageFormatterComponent extends RawFormatterComponent {
     static lateLoadKey = "PercentageFormatterComponent";

--- a/packages/dashboards/src/lib/configurator/components/formatters/raw-formatter/raw-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/raw-formatter/raw-formatter.component.ts
@@ -28,7 +28,8 @@ import {
 import { IFormatterData } from "../types";
 
 @Component({
-    template: ` <ng-container>{{ data?.value }}</ng-container>`,
+    selector: "nui-dashboards-raw-formatter",
+    template: `<ng-container>{{ data?.value }}</ng-container>`,
 })
 export class RawFormatterComponent {
     static lateLoadKey = "RawFormatterComponent";

--- a/packages/dashboards/src/lib/configurator/components/formatters/si-units-formatter/si-units-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/si-units-formatter/si-units-formatter.component.ts
@@ -37,6 +37,7 @@ import {
 import { IFormatterData } from "../types";
 
 @Component({
+    selector: "nui-dashboards-si-units-formatter",
     template: `
         <ng-container>
             <div class="d-flex flex-nowrap">

--- a/packages/dashboards/src/lib/configurator/components/formatters/status-with-icon-formatter/status-with-icon-formatter.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/formatters/status-with-icon-formatter/status-with-icon-formatter.component.ts
@@ -23,6 +23,7 @@ import { ChangeDetectorRef, Component, Input, OnChanges } from "@angular/core";
 import { IHasChangeDetector } from "../../../../types";
 
 @Component({
+    selector: "nui-dashboards-status-icon-formatter",
     template: `
         <ng-container *ngIf="isValid">
             <div


### PR DESCRIPTION
## Frontend Pull Request Description
![image](https://github.com/user-attachments/assets/ad7cda63-eb9c-4fed-9cd0-be9c5d32155c)
https://v16.angular.io/errors/NG0912
https://github.com/angular/angular/issues/50158
<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
