### PR TITLE
fix: renderer and focusMonitor memory leaks v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "15.0.11",
+  "version": "15.0.12",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -206,6 +206,6 @@
     "xliff:lib": "ng extract-i18n lib && ngx-extractor -i \"src/**/*.ts\" -f xlf -o .tmp-i18n/messages.xlf && xliffmerge --profile xliffmerge.json"
   },
   "typings": "public_api.d.ts",
-  "version": "15.0.11",
+  "version": "15.0.12",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "15.0.11",
+  "version": "15.0.12",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/bits/src/lib/menu/menu/menu.component.ts
+++ b/packages/bits/src/lib/menu/menu/menu.component.ts
@@ -158,7 +158,7 @@ export class MenuComponent implements AfterViewInit, OnChanges, OnDestroy {
         // It's more powerful than just listening for focus or blur events because it tells you how the element was focused
         // (via mouse, keyboard, touch, or programmatically).
         this.focusMonitorSubscription = this.focusMonitor
-            .monitor(this.menuToggle.nativeElement)
+            .monitor(this.menuToggle)
             .subscribe((origin: FocusOrigin) => {
                 if (origin === "keyboard") {
                     if (!this.popup.popupToggle.disabled) {
@@ -201,5 +201,6 @@ export class MenuComponent implements AfterViewInit, OnChanges, OnDestroy {
     public ngOnDestroy(): void {
         this.menuKeyControlListeners.forEach((listener) => listener());
         this.focusMonitorSubscription.unsubscribe();
+        this.focusMonitor.stopMonitoring(this.menuToggle);
     }
 }

--- a/packages/bits/src/services/event-bus.service.ts
+++ b/packages/bits/src/services/event-bus.service.ts
@@ -18,7 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Injectable, Renderer2, RendererFactory2 } from "@angular/core";
+import { Injectable, OnDestroy, Renderer2, RendererFactory2 } from "@angular/core";
 
 import { EventBus } from "./event-bus";
 import { DOCUMENT_CLICK_EVENT } from "../constants/event.constants";
@@ -28,8 +28,9 @@ import { DOCUMENT_CLICK_EVENT } from "../constants/event.constants";
  * @ignore
  */
 @Injectable({ providedIn: "root" })
-export class EventBusService extends EventBus<Event> {
+export class EventBusService extends EventBus<Event> implements OnDestroy {
     private renderer: Renderer2;
+    private listenerUnsubscriber?: () => void;
 
     constructor(rendererFactory: RendererFactory2) {
         super();
@@ -38,9 +39,14 @@ export class EventBusService extends EventBus<Event> {
         // This is moved from popup code.
         // Every event that is triggered for document should be handled by popup,
         // but we should register listener only once
-        this.renderer.listen("document", "click", (event: MouseEvent) => {
+        this.listenerUnsubscriber = this.renderer.listen("document", "click", (event: MouseEvent) => {
             // separate stream to detect document-body clicks in case of popup in popover
             this.getStream(DOCUMENT_CLICK_EVENT).next(event);
         });
+    }
+
+    public ngOnDestroy(): void {
+        super.ngOnDestroy();
+        this.listenerUnsubscriber?.();
     }
 }

--- a/packages/bits/src/services/event-bus.service.ts
+++ b/packages/bits/src/services/event-bus.service.ts
@@ -18,7 +18,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Injectable, OnDestroy, Renderer2, RendererFactory2 } from "@angular/core";
+import {
+    Injectable,
+    OnDestroy,
+    Renderer2,
+    RendererFactory2,
+} from "@angular/core";
 
 import { EventBus } from "./event-bus";
 import { DOCUMENT_CLICK_EVENT } from "../constants/event.constants";
@@ -39,10 +44,14 @@ export class EventBusService extends EventBus<Event> implements OnDestroy {
         // This is moved from popup code.
         // Every event that is triggered for document should be handled by popup,
         // but we should register listener only once
-        this.listenerUnsubscriber = this.renderer.listen("document", "click", (event: MouseEvent) => {
-            // separate stream to detect document-body clicks in case of popup in popover
-            this.getStream(DOCUMENT_CLICK_EVENT).next(event);
-        });
+        this.listenerUnsubscriber = this.renderer.listen(
+            "document",
+            "click",
+            (event: MouseEvent) => {
+                // separate stream to detect document-body clicks in case of popup in popover
+                this.getStream(DOCUMENT_CLICK_EVENT).next(event);
+            }
+        );
     }
 
     public ngOnDestroy(): void {

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -98,7 +98,7 @@
   "license": "Apache-2.0",
   "name": "@nova-ui/charts",
   "peerDependencies": {
-    "@nova-ui/bits": "~15.0.11",
+    "@nova-ui/bits": "~15.0.12",
     "@types/d3": "^5.0.0",
     "@types/d3-selection-multi": "^1.0.0",
     "d3": "^5.0.0",
@@ -167,5 +167,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "15.0.11"
+  "version": "15.0.12"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -109,8 +109,8 @@
   "license": "Apache-2.0",
   "name": "@nova-ui/dashboards",
   "peerDependencies": {
-    "@nova-ui/bits": "~15.0.11",
-    "@nova-ui/charts": "~15.0.11",
+    "@nova-ui/bits": "~15.0.12",
+    "@nova-ui/charts": "~15.0.12",
     "angular-gridster2": "^15.0.0",
     "d3": "^5.9.2",
     "d3-selection-multi": "^1.0.1"
@@ -179,5 +179,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "15.0.11"
+  "version": "15.0.12"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "15.0.11",
+  "version": "15.0.12",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/dashboards/scripts/compile-demo-paths.js
+++ b/packages/dashboards/scripts/compile-demo-paths.js
@@ -19,7 +19,7 @@ const getFilesRecursively = (directory) => {
 getFilesRecursively(dir);
 
 const trimmedFiles = files.map((filePath) =>
-    filePath.replaceAll("\\", "/").replace(dir, "")
+    filePath.replace(/\\/g, "/").replace(dir, "")
 );
 
 fs.writeFileSync(

--- a/packages/dashboards/src/lib/pizzagna/directives/component-portal/component-portal.directive.ts
+++ b/packages/dashboards/src/lib/pizzagna/directives/component-portal/component-portal.directive.ts
@@ -68,6 +68,7 @@ export class ComponentPortalDirective
     private providerInstances: Record<string, any> = {};
     private readonly destroy$ = new Subject<void>();
     private changesSubscription?: Subscription;
+    private listenerUnsubscriber?: () => void;
 
     constructor(
         private injector: Injector,
@@ -129,6 +130,7 @@ export class ComponentPortalDirective
         this.logger.debug("Portal destroyed:", this.componentId);
 
         this.destroyProviders();
+        this.listenerUnsubscriber?.();
 
         this.destroy$.next();
         this.destroy$.complete();
@@ -139,7 +141,7 @@ export class ComponentPortalDirective
 
         // ctrl+shift+click on a pizzagna to get a dump of its properties
         // this will propagate through the parent components, so it should dump the parent pizzagnas as well
-        this.renderer.listen(
+        this.listenerUnsubscriber = this.renderer.listen(
             componentRef.location.nativeElement,
             "click",
             (event: MouseEvent) => {


### PR DESCRIPTION
## Frontend Pull Request Description

- Fixes some memory leaks caused by wrong use of focusMonitor and renderer.
- Also fixes Dashboards build on Node 14

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
