### PR TITLE
configurator should also pass preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "16.0.8-0",
+  "version": "16.0.9-0",
   "workspaces": [
     "packages/*"
   ]

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -129,6 +129,6 @@
     "xliff:lib": "ng extract-i18n lib && ngx-extractor -i \"src/**/*.ts\" -f xlf -o .tmp-i18n/messages.xlf && xliffmerge --profile xliffmerge.json"
   },
   "typings": "public_api.d.ts",
-  "version": "16.0.8-0",
+  "version": "16.0.9-0",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "16.0.8-0",
+  "version": "16.0.9-0",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "name": "@nova-ui/charts",
   "peerDependencies": {
-    "@nova-ui/bits": "~16.0.8-0",
+    "@nova-ui/bits": "~16.0.9-0",
     "@types/d3": "^5.0.0",
     "@types/d3-selection-multi": "^1.0.0",
     "d3": "^5.0.0",
@@ -101,5 +101,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "16.0.8-0"
+  "version": "16.0.9-0"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -47,8 +47,8 @@
   "license": "Apache-2.0",
   "name": "@nova-ui/dashboards",
   "peerDependencies": {
-    "@nova-ui/bits": "~16.0.8-0",
-    "@nova-ui/charts": "~16.0.8-0",
+    "@nova-ui/bits": "~16.0.9-0",
+    "@nova-ui/charts": "~16.0.9-0",
     "angular-gridster2": "^15.0.0",
     "d3": "^5.9.2",
     "d3-selection-multi": "^1.0.1"
@@ -116,5 +116,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "16.0.8-0"
+  "version": "16.0.9-0"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "16.0.8-0",
+  "version": "16.0.9-0",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/dashboards/src/lib/components/kpi-widget/kpi.component.html
+++ b/packages/dashboards/src/lib/components/kpi-widget/kpi.component.html
@@ -13,99 +13,65 @@
 </div>
 
 <ng-template #kpiContent>
-    <div
-        class="nui-kpi-indicator__background"
-        [class.nui-kpi-indicator--interactive]="interactive"
-        [ngStyle]="{
-            'background-color': backgroundColor || widgetData?.backgroundColor
-        }"
-    ></div>
-    <div
-        class="nui-kpi-indicator__text"
-        [ngStyle]="{
-            color:
-                widgetData?.textColor ||
-                backgroundColor ||
-                widgetData?.backgroundColor ||
-                defaultColor
-        }"
-    >
+    <div class="nui-kpi-indicator__background"
+         [class.nui-kpi-indicator--interactive]="interactive"
+         [ngStyle]="{'background-color': backgroundColor || widgetData?.backgroundColor}">
+    </div>
+    <div class="nui-kpi-indicator__text"
+         [ngStyle]="{'color': widgetData?.textColor || backgroundColor ||  widgetData?.backgroundColor || defaultColor}">
         <div class="nui-kpi-indicator__zoom-container">
-            <div
-                class="nui-kpi-indicator__description"
-                [title]="widgetData?.label"
-            >
-                <span
-                    nuiZoomContent
-                    [useZoom]="false"
-                    [minScale]="0.5"
-                    [scaleIN$]="getScaleBroker('label')?.out$"
-                    [scaleOUT$]="getScaleBroker('label')?.in$"
-                    >{{ widgetData?.label }}</span
-                >
+            <div class="nui-kpi-indicator__description nui-kpi-indicator__zoom-container__row"
+                 [title]="widgetData?.label">
+                    <span nuiZoomContent
+                          [useZoom]="false"
+                          [minScale]="0.5"
+                          [scaleIN$]="getScaleBroker('label')?.out$"
+                          [scaleOUT$]="getScaleBroker('label')?.in$"
+                    >{{widgetData?.label}}</span>
             </div>
 
-            <ng-container
-                *ngIf="configuration?.formatters?.Value; else kpiValueRaw"
-                nuiComponentPortal
-                #componentPortal="nuiComponentPortal"
-                componentId="KpiValueFormatter"
-                [componentType]="
-                    configuration?.formatters?.Value?.formatter?.componentType
-                "
-                [properties]="formattersProperties.Value"
-            >
-                <div class="nui-kpi-indicator__value">
-                    <span
-                        nuiZoomContent
-                        [ngClass]="
-                            configuration?.formatters?.Value?.formatter
-                                ?.componentType === 'IconFormatterComponent'
-                                ? 'without-filter'
-                                : ''
-                        "
-                        [useZoom]="false"
-                        [scaleIN$]="getScaleBroker('value')?.out$"
-                        [scaleOUT$]="getScaleBroker('value')?.in$"
-                    >
-                        <ng-template
-                            [cdkPortalOutlet]="componentPortal.portal"
-                            (attached)="componentPortal.attached($event)"
-                        ></ng-template>
-                    </span>
+            <ng-container *ngIf="configuration?.formatters?.Value; else kpiValueRaw"
+                          nuiComponentPortal
+                          #componentPortal="nuiComponentPortal"
+                          componentId="KpiValueFormatter"
+                          [componentType]="configuration?.formatters?.Value?.formatter?.componentType"
+                          [properties]="formattersProperties.Value">
+                <div class="nui-kpi-indicator__value nui-kpi-indicator__zoom-container__row">
+                            <span nuiZoomContent
+                                  [ngClass]="configuration?.formatters?.Value?.formatter?.componentType === 'IconFormatterComponent' ? 'without-filter' : ''"
+                                  [useZoom]="false"
+                                  [margin]="widgetData.margin ?? 2"
+                                  [scaleIN$]="getScaleBroker('value')?.out$"
+                                  [scaleOUT$]="getScaleBroker('value')?.in$">
+                                <ng-template
+                                    [cdkPortalOutlet]="componentPortal.portal"
+                                    (attached)="componentPortal.attached($event)"></ng-template>
+                            </span>
                 </div>
             </ng-container>
 
-            <div class="nui-kpi-indicator__units" [title]="widgetData?.units">
-                <span
-                    nuiZoomContent
-                    [useZoom]="false"
-                    [scaleIN$]="getScaleBroker('units')?.out$"
-                    [scaleOUT$]="getScaleBroker('units')?.in$"
-                    [minScale]="0.5"
-                    >{{ widgetData?.units }}</span
-                >
+            <div class="nui-kpi-indicator__units nui-kpi-indicator__zoom-container__row"
+                 *ngIf="widgetData?.units"
+                 [title]="widgetData?.units">
+                    <span nuiZoomContent
+                          [useZoom]="false"
+                          [scaleIN$]="getScaleBroker('units')?.out$"
+                          [scaleOUT$]="getScaleBroker('units')?.in$"
+                          [minScale]="0.5">{{widgetData?.units}}</span>
             </div>
         </div>
     </div>
 </ng-template>
 
 <ng-template #kpiValueRaw>
-    <div
-        class="nui-kpi-indicator__value"
-        [style.font-size]="widgetData?.fontSize"
-        [title]="widgetData?.value"
-    >
-        <div *ngIf="showEmpty" class="is-empty">
-            <nui-image image="no-data-to-show"></nui-image>
-        </div>
-        <span
-            nuiZoomContent
-            [useZoom]="false"
-            [scaleIN$]="getScaleBroker('value')?.out$"
-            [scaleOUT$]="getScaleBroker('value')?.in$"
-        >
-            {{ showEmpty ? "" : widgetData?.value }}</span
-        >
+    <div class="nui-kpi-indicator__value nui-kpi-indicator__zoom-container__row"
+         [style.font-size]="widgetData?.fontSize"
+         [title]="widgetData?.value">
+   <span nuiZoomContent
+         [useZoom]="false"
+         [margin]="widgetData.margin ?? 2"
+         [scaleIN$]="getScaleBroker('value')?.out$"
+         [scaleOUT$]="getScaleBroker('value')?.in$">
+       {{widgetData?.value}}</span>
     </div>
 </ng-template>

--- a/packages/dashboards/src/lib/components/kpi-widget/kpi.component.less
+++ b/packages/dashboards/src/lib/components/kpi-widget/kpi.component.less
@@ -82,11 +82,16 @@
     &__zoom-container {
         display: grid;
         grid-template-columns: 1fr;
-        grid-template-rows: 30% 40% 30%;
         width: 100%;
         height: 100%;
     }
+    &__zoom-container:has(.nui-kpi-indicator__zoom-container__row:nth-child(3)) {
+        grid-template-rows: 30% 40% 30%;
+    }
 
+    &__zoom-container:not(:has(.nui-kpi-indicator__zoom-container__row:nth-child(3))) {
+        grid-template-rows: 30% 70%;
+    }
     &--interactive {
         cursor: pointer;
 

--- a/packages/dashboards/src/lib/components/kpi-widget/types.ts
+++ b/packages/dashboards/src/lib/components/kpi-widget/types.ts
@@ -35,6 +35,7 @@ export interface IKpiData {
     fontSize?: string;
     numberFormat?: string;
     link?: string;
+    margin?: number;
     [key: string]: any;
 }
 

--- a/packages/dashboards/src/lib/configurator/components/widget-editor/widget-editor.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widget-editor/widget-editor.component.ts
@@ -94,7 +94,7 @@ export class WidgetEditorComponent
         public changeDetector: ChangeDetectorRef,
         private formBuilder: FormBuilder,
         private previewService: PreviewService,
-        private configurator: ConfiguratorComponent
+        public configurator: ConfiguratorComponent
     ) {
         this.form = this.formBuilder.group({});
     }

--- a/packages/dashboards/src/lib/configurator/services/widget-editor.service.ts
+++ b/packages/dashboards/src/lib/configurator/services/widget-editor.service.ts
@@ -18,7 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Injectable } from "@angular/core";
+import { ComponentRef, Injectable } from "@angular/core";
 import cloneDeep from "lodash/cloneDeep";
 import { Observable } from "rxjs";
 
@@ -31,6 +31,8 @@ import { IComponentPortalBundle, IWidgetEditor } from "./types";
 
 @Injectable()
 export class WidgetEditorService {
+    private ref: ComponentRef<WidgetEditorComponent>;
+
     constructor(
         private configuratorService: ConfiguratorService,
         private componentPortalService: ComponentPortalService
@@ -48,6 +50,9 @@ export class WidgetEditorService {
                     editorComponent.formPizzagna = widgetEditor.formPizzagna;
                     editorComponent.formRoot = widgetEditor.paths?.root;
                     editorComponent.changeDetector.markForCheck();
+                    setTimeout(() => {
+                        this.ref = componentRef;
+                    });
                 },
             };
 
@@ -60,7 +65,8 @@ export class WidgetEditorService {
         // wipe the data layer of the preview
         delete widgetClone.pizzagna[PizzagnaLayer.Data];
         widgetEditor.widget = widgetClone;
-
+        widgetEditor.previewPizzagnaComponent = () =>
+            this.ref.instance.configurator.getPreview();
         return this.configuratorService.open(widgetEditor);
     }
 }


### PR DESCRIPTION
## Frontend Pull Request Description
This Pr add an abilit in editor see the preview widget easiliy
It fixes the Kpi tiles when no units provided also improves the scales for tiles values.

<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
new look with out units
before:
![image](https://github.com/user-attachments/assets/7cf3a856-f543-47b1-a9f2-f261dd5950a8)

after:
![image](https://github.com/user-attachments/assets/46a929fb-a35b-477c-a578-8972cde59b21)



scale improvment
before: 
![image](https://github.com/user-attachments/assets/9793f120-c3a1-41a5-a27d-f277eb17475d)

after: 
![image](https://github.com/user-attachments/assets/eaab2c1f-e962-40b9-8ae4-d09551e0e1f4)


note: 
sync broker not helping in that case because on exrimely small height of the widget the 10 pixesls by default making value not readable

see orion example: 
![image](https://github.com/user-attachments/assets/db18a320-767a-4d4f-ad20-469748b803ea)

in that case this values will be atleast have more scale. 


<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
