### PR TITLE
fix: raise scroll shadow above the content

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [16.0.9.1] 📅 2025-04-03
+### Bugfix
+- `@nova-ui/bits` | Removed inline-block from sorter compoenent causing input style break
+- `@nova-ui/dashboard` | Raised scroll shadow in the widget cloner above the content
+
 ## [16.0.6] 📅 2025-03-12
 ### Added
 - `@nova-ui/bits` | Added unit conversion for milliseconds

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "16.0.9-0",
+  "version": "16.0.9-1",
   "workspaces": [
     "packages/*"
   ]

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -129,6 +129,6 @@
     "xliff:lib": "ng extract-i18n lib && ngx-extractor -i \"src/**/*.ts\" -f xlf -o .tmp-i18n/messages.xlf && xliffmerge --profile xliffmerge.json"
   },
   "typings": "public_api.d.ts",
-  "version": "16.0.9-0",
+  "version": "16.0.9-1",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "16.0.9-0",
+  "version": "16.0.9-1",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/bits/src/lib/sorter/sorter.component.html
+++ b/packages/bits/src/lib/sorter/sorter.component.html
@@ -1,28 +1,26 @@
 <div>
     <label *ngIf="caption" class="nui-sorter__label">{{ caption }}</label>
-    <div class="btn-group nui-sorter__popup">
-        <div class="d-inline-block" #toggleRef>
-            <button
-                nui-button
-                type="button"
-                class="nui-sorter__toggle-button"
-                [icon]="getSortIcon()"
-                [ariaLabel]="getAriaLabelForSortingButton()"
-                (click)="toggleSortDirection()"
-            >
-                <span class="nui-sorter__display-value">{{
-                    getSelectedItemTitle()
-                }}</span>
-            </button>
-            <button
-                nui-button
-                type="button"
-                class="nui-selector__toggle"
-                (click)="toggleSorterMenu()"
-                ariaLabel="Open Sorter Menu"
-                icon="caret-down"
-            ></button>
-        </div>
+    <div class="btn-group nui-sorter__popup" #toggleRef>
+        <button
+            nui-button
+            type="button"
+            class="nui-sorter__toggle-button"
+            [icon]="getSortIcon()"
+            [ariaLabel]="getAriaLabelForSortingButton()"
+            (click)="toggleSortDirection()"
+        >
+            <span class="nui-sorter__display-value">
+                {{ getSelectedItemTitle() }}
+            </span>
+        </button>
+        <button
+            nui-button
+            type="button"
+            class="nui-selector__toggle"
+            (click)="toggleSorterMenu()"
+            ariaLabel="Open Sorter Menu"
+            icon="caret-down"
+        ></button>
     </div>
 
     <div #popupArea></div>

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -101,5 +101,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "16.0.9-0"
+  "version": "16.0.9-1"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -116,5 +116,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "16.0.9-0"
+  "version": "16.0.9-1"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "16.0.9-0",
+  "version": "16.0.9-1",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/dashboards/src/lib/configurator/components/widget-cloner/widget-cloner.component.html
+++ b/packages/dashboards/src/lib/configurator/components/widget-cloner/widget-cloner.component.html
@@ -1,8 +1,10 @@
 <nui-configurator-heading
     configuratorTitle="Creating Widget"
     i18n-configuratorTitle
+    class="header"
     (close)="onCancel()"
     [disableCloseButton]="busy"
+    [class.shadow]="scrolled"
 ></nui-configurator-heading>
 <nui-dashwiz
     [hideHeader]="true"

--- a/packages/dashboards/src/lib/configurator/components/widget-cloner/widget-cloner.component.less
+++ b/packages/dashboards/src/lib/configurator/components/widget-cloner/widget-cloner.component.less
@@ -1,0 +1,11 @@
+@import (reference) "@nova-ui/bits/sdk/less/nui-framework-variables";
+@import (reference) "@nova-ui/bits/sdk/less/nui-framework-shadow";
+@import (reference) "@nova-ui/bits/sdk/less/mixins";
+
+.header {
+    transition: box-shadow 0.3s ease-in-out;
+
+    &.shadow {
+        box-shadow: @nui-shadow-stronger;
+    }
+}

--- a/packages/dashboards/src/lib/configurator/components/widget-cloner/widget-cloner.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/widget-cloner/widget-cloner.component.ts
@@ -18,6 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import { CdkScrollable, ScrollDispatcher } from "@angular/cdk/overlay";
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
@@ -47,6 +48,7 @@ import { IDashwizStepNavigatedEvent, IDashwizWaitEvent } from "../wizard/types";
 @Component({
     selector: "nui-widget-cloner",
     templateUrl: "./widget-cloner.component.html",
+    styleUrls: ["./widget-cloner.component.less"],
     host: { class: "d-flex flex-column h-100" },
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -69,6 +71,7 @@ export class WidgetClonerComponent
     private readonly destroy$ = new Subject<void>();
     private resetForm$ = new Subject<void>();
     public busy = false;
+    public scrolled = false;
     public isFormDisplayed = false;
 
     constructor(
@@ -76,7 +79,8 @@ export class WidgetClonerComponent
         public configurator: ConfiguratorComponent,
         private previewService: PreviewService,
         private formBuilder: FormBuilder,
-        private widgetTypesService: WidgetTypesService
+        private widgetTypesService: WidgetTypesService,
+        private scrollDispatcher: ScrollDispatcher
     ) {
         this.resetForm();
     }
@@ -98,6 +102,17 @@ export class WidgetClonerComponent
     public ngAfterViewInit(): void {
         // trigger dashwiz to update its button configuration
         this.changeDetector.markForCheck();
+
+        // Scroll shadows
+        this.scrollDispatcher.scrolled()
+            .subscribe((event: CdkScrollable | void) => {
+                const element = event?.getElementRef()?.nativeElement;
+
+                if (element?.classList?.contains("configurator-scrollable")) {
+                    this.scrolled = !!element?.scrollTop;
+                    this.changeDetector.detectChanges();
+                }
+            });
     }
 
     public ngOnDestroy(): void {

--- a/packages/dashboards/src/lib/configurator/components/wizard/dashwiz-step/dashwiz-step.component.html
+++ b/packages/dashboards/src/lib/configurator/components/wizard/dashwiz-step/dashwiz-step.component.html
@@ -6,7 +6,7 @@
 >
     <div
         cdkScrollable
-        class="h-100 overflow-auto nui-scroll-shadows configurator-scrollable"
+        class="h-100 overflow-auto configurator-scrollable"
     >
         <ng-container *ngTemplateOutlet="stepTemplate"></ng-container>
     </div>

--- a/packages/dashboards/src/lib/configurator/components/wizard/dashwiz/dashwiz.component.html
+++ b/packages/dashboards/src/lib/configurator/components/wizard/dashwiz/dashwiz.component.html
@@ -33,8 +33,8 @@
                                         class="nui-dashwiz__header-step-title"
                                         #stepTitle
                                     >
-                                        {{ step.title }}</span
-                                    >
+                                        {{ step.title }}
+                                    </span>
                                     <div
                                         class="nui-dashwiz__header-step-link-container"
                                     >
@@ -74,12 +74,15 @@
         </ul>
     </div>
 
-    <div class="nui-scroll-shadows flex-grow-1 overflow-auto">
+    <div class="flex-grow-1 overflow-auto">
         <ng-content></ng-content>
         <ng-template #container></ng-template>
     </div>
 
-    <div class="nui-dashwiz__footer">
+    <div
+        class="nui-dashwiz__footer"
+        [class.shadow]="scrolled"
+    >
         <ng-container
             nuiComponentPortal
             componentId="dashwizButtons"

--- a/packages/dashboards/src/lib/configurator/components/wizard/dashwiz/dashwiz.component.less
+++ b/packages/dashboards/src/lib/configurator/components/wizard/dashwiz/dashwiz.component.less
@@ -166,5 +166,10 @@
         .setCssVariable(background-color, nui-color-bg-content);
         border-top: solid 1px
             var(--nui-color-line-default, @nui-color-line-default);
+        transition: box-shadow 0.3s ease-in-out;
+
+        &.shadow {
+            box-shadow: @nui-shadow-stronger;
+        }
     }
 }

--- a/packages/dashboards/src/lib/configurator/components/wizard/dashwiz/dashwiz.component.ts
+++ b/packages/dashboards/src/lib/configurator/components/wizard/dashwiz/dashwiz.component.ts
@@ -18,6 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import { ScrollDispatcher } from "@angular/cdk/overlay";
 import {
     AfterContentInit,
     AfterViewChecked,
@@ -65,8 +66,7 @@ import { IDashwizComponent } from "./model";
     host: { class: "flex-grow-1 overflow-auto" },
 })
 export class DashwizComponent
-    implements
-        OnInit,
+    implements OnInit,
         AfterContentInit,
         AfterViewChecked,
         OnDestroy,
@@ -143,6 +143,7 @@ export class DashwizComponent
     public stepLineWidth: number = 65;
     public stepIndex: number;
     public buttonProperties: IDashwizButtonsComponent;
+    public scrolled = false;
 
     private stepNavigatedEvent: IDashwizStepNavigatedEvent;
     private previousStepIndex = 0;
@@ -154,7 +155,8 @@ export class DashwizComponent
         private changeDetector: ChangeDetectorRef,
         private componentFactoryResolver: ComponentFactoryResolver,
         private logger: LoggerService,
-        private dashwizService: DashwizService
+        private dashwizService: DashwizService,
+        private scrollDispatcher: ScrollDispatcher
     ) {
         if (dashwizService) {
             dashwizService.component = this;
@@ -162,6 +164,14 @@ export class DashwizComponent
     }
 
     public ngOnInit(): void {
+        this.scrollDispatcher.scrolled().subscribe((event) => {
+            const element = event?.getElementRef()?.nativeElement;
+
+            if (element?.classList?.contains("configurator-scrollable")) {
+                this.scrolled = !!element?.scrollTop;
+            }
+        })
+
         this.buttonComponentTypes = this.buttonComponentTypes || [
             DashwizButtonsComponent.lateLoadKey,
         ];


### PR DESCRIPTION
## Frontend Pull Request Description

- `@nova-ui/bits` | Removed inline-block from sorter compoenent causing input style break
- `@nova-ui/dashboard` | Raised scroll shadow in the widget cloner above the content
- Updated version to 16.0.9-1

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
