### PR TITLE
OO-49414 Ability to disable refreshers globaly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Changelog
 
+## [17.0.1] 📅 2025-07-31
+
+### Added
+
+- `@nova-ui/dashboards` | Added ability to globaly disable refreshers
+
 ## [17.0.0] 📅 2025-04-20
 ### Angular upgrade 17
 
 ## [16.0.9] 📅 2025-04-02
 ### Fixes
--
 - `@nova-ui/dashboards` | Fix kpi scale for values
 - `@nova-ui/dashboards` | Fix editor preview component
 - `@nova-ui/dashboards` | Fix search addon listening chagnes
 
 ## [16.0.8] 📅 2025-04-02
 ### Fixes
--
 - `@nova-ui/dashboards` | Fix selection config
 - `@nova-ui/dashboards` | Added ability to listen preview component through the cloner
 

--- a/packages/dashboards/src/lib/components/providers/refresher-settings.service.ts
+++ b/packages/dashboards/src/lib/components/providers/refresher-settings.service.ts
@@ -30,19 +30,22 @@ import { DEFAULT_REFRESH_INTERVAL } from "./types";
     providedIn: "root",
 })
 export class RefresherSettingsService {
-    private _refreshRateSeconds: number = DEFAULT_REFRESH_INTERVAL;
-    public refreshRateSeconds$ = new BehaviorSubject(this.refreshRateSeconds);
+    /**
+     * This is a system wide definition for disabling all refreshers.
+     */
+    public readonly disabled$ = new BehaviorSubject(false);
+
+    public readonly refreshRateSeconds$ = new BehaviorSubject(DEFAULT_REFRESH_INTERVAL);
 
     /**
      * This is a system wide definition of refresh rate. Widgets have to be configured to use
      * the system settings to leverage this value.
      */
     public get refreshRateSeconds(): number {
-        return this._refreshRateSeconds;
+        return this.refreshRateSeconds$.value;
     }
 
     public set refreshRateSeconds(value: number) {
-        this._refreshRateSeconds = value;
-        this.refreshRateSeconds$.next(this._refreshRateSeconds);
+        this.refreshRateSeconds$.next(value);
     }
 }

--- a/packages/dashboards/src/lib/components/providers/refresher.ts
+++ b/packages/dashboards/src/lib/components/providers/refresher.ts
@@ -19,8 +19,7 @@
 //  THE SOFTWARE.
 
 import { Inject, Injectable, NgZone, OnDestroy } from "@angular/core";
-import { Subject } from "rxjs";
-import { takeUntil } from "rxjs/operators";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 import { EventBus, EventDefinition } from "@nova-ui/bits";
 
@@ -50,19 +49,23 @@ export class Refresher implements OnDestroy, IConfigurable {
     protected interval = DEFAULT_REFRESH_INTERVAL;
     protected eventDef = REFRESH;
 
-    public readonly destroy$ = new Subject<void>();
-
     constructor(
-        @Inject(PIZZAGNA_EVENT_BUS) protected eventBus: EventBus<IWidgetEvent>,
-        protected ngZone: NgZone,
-        protected refresherSettings: RefresherSettingsService
+        @Inject(PIZZAGNA_EVENT_BUS) protected readonly eventBus: EventBus<IWidgetEvent>,
+        protected readonly ngZone: NgZone,
+        protected readonly refresherSettings: RefresherSettingsService
     ) {
         this.refresherSettings.refreshRateSeconds$
-            .pipe(takeUntil(this.destroy$))
-            .subscribe((systemRefreshRate) => {
+            .pipe(takeUntilDestroyed())
+            .subscribe(() => {
                 if (!this.overrideDefaultSettings) {
                     this.initializeInterval();
                 }
+            });
+
+        this.refresherSettings.disabled$
+            .pipe(takeUntilDestroyed())
+            .subscribe(() => {
+                this.initializeInterval();
             });
     }
 
@@ -78,8 +81,6 @@ export class Refresher implements OnDestroy, IConfigurable {
 
     public ngOnDestroy(): void {
         this.clearInterval();
-        this.destroy$.next();
-        this.destroy$.complete();
     }
 
     private initializeInterval() {
@@ -88,7 +89,8 @@ export class Refresher implements OnDestroy, IConfigurable {
         if (
             typeof this.interval === "undefined" ||
             this.getInterval() <= 0 ||
-            this.enabled === false
+            this.enabled === false ||
+            this.refresherSettings.disabled$.value === true
         ) {
             return;
         }


### PR DESCRIPTION
## Frontend Pull Request Description

New Refresher global setting to disable them.

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Context (if necessary)

The goal is to have a web setting that when set, it would disable all refreshes on the web when the page is not active. There currently is not way to disable refreshes in Nova.
