### PR TITLE
OO-49414 Make RefresherSettingsService singleton [v17]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [17.0.3] 📅 2025-08-05
+
+### Fixes
+
+- `@nova-ui/dashboards` | `RefresherSettingsService` is now truly a singleton and can be used to configure refreshers in dashboard module
+
 ## [17.0.2] 📅 2025-07-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "17.0.2",
+  "version": "17.0.3",
   "workspaces": [
     "packages/*"
   ]

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -126,6 +126,6 @@
     "xliff:lib": "ng extract-i18n lib && ngx-extractor -i \"src/**/*.ts\" -f xlf -o .tmp-i18n/messages.xlf && xliffmerge --profile xliffmerge.json"
   },
   "typings": "public_api.d.ts",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -101,5 +101,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "17.0.2"
+  "version": "17.0.3"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -116,5 +116,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "17.0.2"
+  "version": "17.0.3"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/dashboards/src/lib/dashboards.module.ts
+++ b/packages/dashboards/src/lib/dashboards.module.ts
@@ -65,7 +65,6 @@ import { ListWidgetComponent } from "./components/list-widget/list-widget.compon
 import { LoadingComponent } from "./components/loading/loading.component";
 import { ProportionalDonutContentComponent } from "./components/proportional-widget/proportional-donut-content/proportional-donut-content.component";
 import { ProportionalWidgetComponent } from "./components/proportional-widget/proportional-widget.component";
-import { RefresherSettingsService } from "./components/providers/refresher-settings.service";
 import { RiskScoreTileComponent } from "./components/risk-score-tile/risk-score-tile.component";
 import { DelayedMousePresenceDetectionDirective } from "./components/table-widget/delayed-mouse-presence-detection.directive";
 import { TableWidgetComponent } from "./components/table-widget/table-widget.component";
@@ -221,7 +220,6 @@ const entryComponents: IComponentWithLateLoadKey[] = [
         ComponentPortalService,
         WidgetTypesService,
         DecimalPipe,
-        RefresherSettingsService,
     ],
     exports: dashboardComponents,
 })


### PR DESCRIPTION
## Frontend Pull Request Description

- Follow up on https://github.com/solarwinds/nova/pull/767
- The issue with `RefresherSettingsService` is that while it's marked as `providedIn: "root"` it was added to the module providers. This effectively makes a new instance for the module and rest of the code works with a different instance so nothing outside of this module could change the settings.

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
