### PR TITLE
Revert "OO-49414 Ability to disable refreshers globaly [v17] (#767)"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,6 @@
 ### Fixes
 - `@nova-ui/dashboards` | Fix kpi scale brokers duplication on config change
 
-## [17.0.2] 📅 2025-07-31
-### Added
-- `@nova-ui/dashboards` | Added the ability to globally disable refreshers
-
 ## [17.0.0] 📅 2025-04-20
 ### Angular upgrade 17
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "17.0.3",
+  "version": "17.0.4",
   "workspaces": [
     "packages/*"
   ]

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -126,6 +126,6 @@
     "xliff:lib": "ng extract-i18n lib && ngx-extractor -i \"src/**/*.ts\" -f xlf -o .tmp-i18n/messages.xlf && xliffmerge --profile xliffmerge.json"
   },
   "typings": "public_api.d.ts",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -101,5 +101,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "17.0.3"
+  "version": "17.0.4"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -116,5 +116,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "17.0.3"
+  "version": "17.0.4"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/dashboards/src/lib/components/providers/refresher-settings.service.ts
+++ b/packages/dashboards/src/lib/components/providers/refresher-settings.service.ts
@@ -30,22 +30,19 @@ import { DEFAULT_REFRESH_INTERVAL } from "./types";
     providedIn: "root",
 })
 export class RefresherSettingsService {
-    /**
-     * This is a system wide definition for disabling all refreshers.
-     */
-    public readonly disabled$ = new BehaviorSubject(false);
-
-    public readonly refreshRateSeconds$ = new BehaviorSubject(DEFAULT_REFRESH_INTERVAL);
+    private _refreshRateSeconds: number = DEFAULT_REFRESH_INTERVAL;
+    public refreshRateSeconds$ = new BehaviorSubject(this.refreshRateSeconds);
 
     /**
      * This is a system wide definition of refresh rate. Widgets have to be configured to use
      * the system settings to leverage this value.
      */
     public get refreshRateSeconds(): number {
-        return this.refreshRateSeconds$.value;
+        return this._refreshRateSeconds;
     }
 
     public set refreshRateSeconds(value: number) {
-        this.refreshRateSeconds$.next(value);
+        this._refreshRateSeconds = value;
+        this.refreshRateSeconds$.next(this._refreshRateSeconds);
     }
 }

--- a/packages/dashboards/src/lib/components/providers/refresher.spec.ts
+++ b/packages/dashboards/src/lib/components/providers/refresher.spec.ts
@@ -40,11 +40,9 @@ describe("Refresher > ", () => {
     });
 
     beforeEach(() => {
-        eventBus = new EventBus<IEvent>();
+        eventBus = new EventBus();
         refresherSettings = new RefresherSettingsService();
-        TestBed.runInInjectionContext(() => {
-            refresher = new Refresher(eventBus, ngZone, refresherSettings);
-        });
+        refresher = new Refresher(eventBus, ngZone, refresherSettings);
     });
 
     describe("updateConfiguration > ", () => {
@@ -66,20 +64,16 @@ describe("Refresher > ", () => {
 
     describe("ngOnDestroy > ", () => {
         it("should clear the interval", fakeAsync(() => {
-            const spy = spyOn(eventBus.getStream(REFRESH), "next");
-            refresher.updateConfiguration({});
-            // Sanity check
-            tick(DEFAULT_REFRESH_INTERVAL * 1000);
-            expect(spy).toHaveBeenCalledTimes(1);
-            // Verify
+            refresher = new Refresher(eventBus, ngZone, refresherSettings);
             refresher.ngOnDestroy();
-            tick(DEFAULT_REFRESH_INTERVAL * 1000 * 2);
-            expect(spy).toHaveBeenCalledTimes(1);
+            const spy = spyOn(eventBus.getStream(REFRESH), "next");
+            tick(DEFAULT_REFRESH_INTERVAL * 2);
+            expect(spy).toHaveBeenCalledTimes(0);
         }));
     });
 
     describe("refresherSettings", () => {
-        it("updates interval when global settings interval changes", fakeAsync(() => {
+        it("updates interval when global settings change", fakeAsync(() => {
             refresherSettings.refreshRateSeconds = 1;
             refresher.updateConfiguration({ overrideDefaultSettings: false });
             const spy = spyOn(eventBus.getStream(REFRESH), "next");
@@ -92,26 +86,6 @@ describe("Refresher > ", () => {
             expect(spy).toHaveBeenCalledTimes(1);
             tick(1999);
             expect(spy).toHaveBeenCalledTimes(2);
-            refresher.ngOnDestroy();
-        }));
-
-        it("disables interval when global disabled settings changes", fakeAsync(() => {
-            refresher.updateConfiguration({});
-            const spy = spyOn(eventBus.getStream(REFRESH), "next");
-            // Sanity check
-            tick(DEFAULT_REFRESH_INTERVAL * 1000);
-            expect(spy).toHaveBeenCalledTimes(1);
-
-            // Verify disabling
-            refresherSettings.disabled$.next(true);
-            tick(DEFAULT_REFRESH_INTERVAL * 1000 * 10);
-            expect(spy).toHaveBeenCalledTimes(1);
-
-            // Verify enabling
-            refresherSettings.disabled$.next(false);
-            tick(DEFAULT_REFRESH_INTERVAL * 1000);
-            expect(spy).toHaveBeenCalledTimes(2);
-
             refresher.ngOnDestroy();
         }));
     });


### PR DESCRIPTION
## Frontend Pull Request Description

- Revert https://github.com/solarwinds/nova/pull/767
- It was implemented entirely in Orion at the end, more details https://github.com/solarwinds-internal/orion/pull/33054

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
