### PR TITLE
Revert "OO-49414 Ability to disable refreshers globaly (#766)"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [17.0.1] 📅 2025-07-31
-
-### Added
-
-- `@nova-ui/dashboards` | Added ability to globaly disable refreshers
-
 ## [17.0.0] 📅 2025-04-20
 ### Angular upgrade 17
 

--- a/packages/dashboards/src/lib/components/providers/refresher-settings.service.ts
+++ b/packages/dashboards/src/lib/components/providers/refresher-settings.service.ts
@@ -30,22 +30,19 @@ import { DEFAULT_REFRESH_INTERVAL } from "./types";
     providedIn: "root",
 })
 export class RefresherSettingsService {
-    /**
-     * This is a system wide definition for disabling all refreshers.
-     */
-    public readonly disabled$ = new BehaviorSubject(false);
-
-    public readonly refreshRateSeconds$ = new BehaviorSubject(DEFAULT_REFRESH_INTERVAL);
+    private _refreshRateSeconds: number = DEFAULT_REFRESH_INTERVAL;
+    public refreshRateSeconds$ = new BehaviorSubject(this.refreshRateSeconds);
 
     /**
      * This is a system wide definition of refresh rate. Widgets have to be configured to use
      * the system settings to leverage this value.
      */
     public get refreshRateSeconds(): number {
-        return this.refreshRateSeconds$.value;
+        return this._refreshRateSeconds;
     }
 
     public set refreshRateSeconds(value: number) {
-        this.refreshRateSeconds$.next(value);
+        this._refreshRateSeconds = value;
+        this.refreshRateSeconds$.next(this._refreshRateSeconds);
     }
 }

--- a/packages/dashboards/src/lib/components/providers/refresher.spec.ts
+++ b/packages/dashboards/src/lib/components/providers/refresher.spec.ts
@@ -40,11 +40,9 @@ describe("Refresher > ", () => {
     });
 
     beforeEach(() => {
-        eventBus = new EventBus<IEvent>();
+        eventBus = new EventBus();
         refresherSettings = new RefresherSettingsService();
-        TestBed.runInInjectionContext(() => {
-            refresher = new Refresher(eventBus, ngZone, refresherSettings);
-        });
+        refresher = new Refresher(eventBus, ngZone, refresherSettings);
     });
 
     describe("updateConfiguration > ", () => {
@@ -66,20 +64,16 @@ describe("Refresher > ", () => {
 
     describe("ngOnDestroy > ", () => {
         it("should clear the interval", fakeAsync(() => {
-            const spy = spyOn(eventBus.getStream(REFRESH), "next");
-            refresher.updateConfiguration({});
-            // Sanity check
-            tick(DEFAULT_REFRESH_INTERVAL * 1000);
-            expect(spy).toHaveBeenCalledTimes(1);
-            // Verify
+            refresher = new Refresher(eventBus, ngZone, refresherSettings);
             refresher.ngOnDestroy();
-            tick(DEFAULT_REFRESH_INTERVAL * 1000 * 2);
-            expect(spy).toHaveBeenCalledTimes(1);
+            const spy = spyOn(eventBus.getStream(REFRESH), "next");
+            tick(DEFAULT_REFRESH_INTERVAL * 2);
+            expect(spy).toHaveBeenCalledTimes(0);
         }));
     });
 
     describe("refresherSettings", () => {
-        it("updates interval when global settings interval changes", fakeAsync(() => {
+        it("updates interval when global settings change", fakeAsync(() => {
             refresherSettings.refreshRateSeconds = 1;
             refresher.updateConfiguration({ overrideDefaultSettings: false });
             const spy = spyOn(eventBus.getStream(REFRESH), "next");
@@ -92,26 +86,6 @@ describe("Refresher > ", () => {
             expect(spy).toHaveBeenCalledTimes(1);
             tick(1999);
             expect(spy).toHaveBeenCalledTimes(2);
-            refresher.ngOnDestroy();
-        }));
-
-        it("disables interval when global disabled settings changes", fakeAsync(() => {
-            refresher.updateConfiguration({});
-            const spy = spyOn(eventBus.getStream(REFRESH), "next");
-            // Sanity check
-            tick(DEFAULT_REFRESH_INTERVAL * 1000);
-            expect(spy).toHaveBeenCalledTimes(1);
-
-            // Verify disabling
-            refresherSettings.disabled$.next(true);
-            tick(DEFAULT_REFRESH_INTERVAL * 1000 * 10);
-            expect(spy).toHaveBeenCalledTimes(1);
-
-            // Verify enabling
-            refresherSettings.disabled$.next(false);
-            tick(DEFAULT_REFRESH_INTERVAL * 1000);
-            expect(spy).toHaveBeenCalledTimes(2);
-
             refresher.ngOnDestroy();
         }));
     });


### PR DESCRIPTION
This reverts commit 5c09f4d0ae8bd9c116290cbb85b33fc85c27354d.

## Frontend Pull Request Description

- Revert of https://github.com/solarwinds/nova/pull/766
- It was implemented entirely in Orion at the end, more details https://github.com/solarwinds-internal/orion/pull/33054
- Reverted also in v17 https://github.com/solarwinds/nova/pull/772

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
