### PR TITLE
Adding aria-checked for the nui-radio component

### DIFF
--- a/packages/bits/src/lib/radio/radio.component.html
+++ b/packages/bits/src/lib/radio/radio.component.html
@@ -17,6 +17,7 @@
                 [checked]="checked"
                 [disabled]="disabled"
                 [attr.aria-label]="ariaLabel"
+                [attr.aria-checked]="checked"
                 (change)="changeHandler()"
                 (click)="onInputClick($event)"
             />


### PR DESCRIPTION
## Frontend Pull Request Description

OO-50705

Ensuring elements with an ARIA roles have all required ARIA attributes

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
