### PR TITLE
Refactor aria-selected handling in nui-tab-heading component

### DIFF
--- a/packages/bits/src/lib/tabgroup/tab-heading/tab-heading.component.html
+++ b/packages/bits/src/lib/tabgroup/tab-heading/tab-heading.component.html
@@ -2,6 +2,7 @@
     [class.active]="active"
     [tabindex]="disabled ? -1 : 0"
     [attr.aria-selected]="active ? 'true' : 'false'"
+    role="tab"
     (click)="selectTab()" 
     (keydown)="onKeyDown($event)">
     <span class="tab-link">

--- a/packages/bits/src/lib/tabgroup/tab-heading/tab-heading.component.ts
+++ b/packages/bits/src/lib/tabgroup/tab-heading/tab-heading.component.ts
@@ -36,7 +36,6 @@ import { KEYBOARD_CODE } from "../../../constants/keycode.constants";
     selector: "nui-tab-heading",
     templateUrl: "./tab-heading.component.html",
     styleUrls: ["./tab-heading.component.less"],
-    host: { role: "tab" },
 })
 export class TabHeadingComponent {
     /** This adds 'disabled' class to the host component depending on the 'disabled' @Input to properly style disabled tabs */


### PR DESCRIPTION
This pull request updates the accessibility implementation of the tab heading component by changing how the `aria-selected` attribute is set. The attribute is now bound directly in the template rather than through a host binding in the TypeScript class, simplifying the code and maintaining correct accessibility semantics.

Accessibility improvements:

* The `[attr.aria-selected]` attribute is now set directly in the `tab-heading.component.html` template, ensuring that the active tab is properly announced to assistive technologies.
* The `@HostBinding` for `aria-selected` and its associated getter have been removed from `tab-heading.component.ts`, reducing code complexity and centralizing the logic in the template.## Frontend Pull Request Description


## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
