### PR TITLE
Bump version to 17.0.7 across all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "17.0.6",
+  "version": "17.0.7",
   "workspaces": [
     "packages/*"
   ]

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -126,6 +126,6 @@
     "xliff:lib": "ng extract-i18n lib && ngx-extractor -i \"src/**/*.ts\" -f xlf -o .tmp-i18n/messages.xlf && xliffmerge --profile xliffmerge.json"
   },
   "typings": "public_api.d.ts",
-  "version": "17.0.6",
+  "version": "17.0.7",
   "packageManager": "yarn@1.22.18"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "17.0.6",
+  "version": "17.0.7",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "name": "@nova-ui/charts",
   "peerDependencies": {
-    "@nova-ui/bits": "~17.0.6",
+    "@nova-ui/bits": "~17.0.7",
     "@types/d3": "^5.0.0",
     "@types/d3-selection-multi": "^1.0.0",
     "d3": "^5.9.2",
@@ -101,5 +101,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "17.0.6"
+  "version": "17.0.7"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -47,8 +47,8 @@
   "license": "Apache-2.0",
   "name": "@nova-ui/dashboards",
   "peerDependencies": {
-    "@nova-ui/bits": "~17.0.6",
-    "@nova-ui/charts": "~17.0.6",
+    "@nova-ui/bits": "~17.0.7",
+    "@nova-ui/charts": "~17.0.7",
     "angular-gridster2": "^15.0.0",
     "d3": "^5.9.2",
     "d3-selection-multi": "^1.0.1"
@@ -116,5 +116,5 @@
     "visual:gui": "yarn run visual:base -c gui",
     "visual:serve": "yarn run visual:base -c serve"
   },
-  "version": "17.0.6"
+  "version": "17.0.7"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "17.0.6",
+  "version": "17.0.7",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
This pull request updates the version numbers for all relevant packages and adjusts peer dependencies to ensure compatibility across the monorepo. The changes are focused on bumping the version from `17.0.6` to `17.0.7` and updating package references accordingly.

Version updates:

* Updated the `version` field from `17.0.6` to `17.0.7` in the root `package.json`, `packages/bits/package.json`, `packages/bits/schematics/package.json`, `packages/charts/package.json`, `packages/dashboards/package.json`, and `packages/dashboards/schematics/package.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L128-R128) [[2]](diffhunk://#diff-7cb8e3d03ce722589c54af24a2aa671d97f986fb760a12e4aa364d708181d97cL129-R129) [[3]](diffhunk://#diff-e65070e1badd57eb8d0738759ffe028e0dee6d5bdb447dcf9c608214d15dd4ddL4-R4) [[4]](diffhunk://#diff-c20c95d8d4049839c1192e0d63fb6d37a43ee3724529bf811bcdd2262b493e0bL104-R104) [[5]](diffhunk://#diff-414f6eab99e1636d6fe7aaf5e87a6cb038bfd042ce9ba946970871aaa8c7dbf1L119-R119) [[6]](diffhunk://#diff-c2c7fd4c9d1f1bbdcf2b2b600840bc6d2b1806bbc490746c8fbd44f723bc9f72L4-R4)

Peer dependency updates:

* Updated peer dependencies in `packages/charts/package.json` and `packages/dashboards/package.json` to require `@nova-ui/bits` and `@nova-ui/charts` at version `~17.0.7` instead of `~17.0.6`. [[1]](diffhunk://#diff-c20c95d8d4049839c1192e0d63fb6d37a43ee3724529bf811bcdd2262b493e0bL39-R39) [[2]](diffhunk://#diff-414f6eab99e1636d6fe7aaf5e87a6cb038bfd042ce9ba946970871aaa8c7dbf1L50-R51)