### PR TITLE
Fixed accessibility requirements on home summary page

### DIFF
--- a/packages/bits/demo/src/components/demo/color-picker/color-picker-basic/color-picker-basic.example.component.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker-basic/color-picker-basic.example.component.ts
@@ -18,7 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import {
     FormBuilder,
     FormControl,
@@ -45,10 +45,10 @@ const CHART_PALETTE_CS1: string[] = [
     styles: [],
     standalone: false,
 })
-export class ColorPickerBasicExampleComponent {
+export class ColorPickerBasicExampleComponent implements OnInit {
     public myForm: FormGroup<{ backgroundColor: FormControl<string | null> }>;
     public colors: string[] = CHART_PALETTE_CS1;
-    
+
     constructor(
         private formBuilder: FormBuilder
     ) {}

--- a/packages/bits/demo/src/components/demo/color-picker/color-picker-palette/color-picker-palette.example.component.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker-palette/color-picker-palette.example.component.ts
@@ -18,12 +18,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import {
     FormBuilder,
     FormControl,
     FormGroup,
 } from "@angular/forms";
+
 import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/color-picker.constants";
 
 
@@ -33,12 +34,12 @@ import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/colo
     styles: [],
     standalone: false,
 })
-export class ColorPickerPaletteExampleComponent {
+export class ColorPickerPaletteExampleComponent implements OnInit {
     public myForm: FormGroup<{ backgroundColor: FormControl<string | null> }>;
     public colorPalette: IPaletteColor[] = Array.from(HTML_COLORS.entries())
     .map(([label, color]) => ({label,color}));
-  
-    
+
+
     constructor(
         private formBuilder: FormBuilder
     ) {}

--- a/packages/bits/demo/src/components/demo/color-picker/color-picker-select/color-picker-select.example.component.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker-select/color-picker-select.example.component.ts
@@ -18,12 +18,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import {
     FormBuilder,
     FormControl,
     FormGroup,
 } from "@angular/forms";
+
 import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/color-picker.constants";
 
 
@@ -33,12 +34,12 @@ import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/colo
     styles: [],
     standalone: false,
 })
-export class ColorPickerSelectExampleComponent {
+export class ColorPickerSelectExampleComponent implements OnInit {
     public myForm: FormGroup<{ backgroundColor: FormControl<string | null> }>;
     public colorPalette: IPaletteColor[] = Array.from(HTML_COLORS.entries())
     .map(([label, color]) => ({label,color}));
-  
-    
+
+
     constructor(
         private formBuilder: FormBuilder
     ) {}

--- a/packages/bits/demo/src/components/demo/color-picker/color-picker.module.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker.module.ts
@@ -19,8 +19,8 @@
 //  THE SOFTWARE.
 
 import { NgModule } from "@angular/core";
-import { RouterModule } from "@angular/router";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { RouterModule } from "@angular/router";
 
 import {
     DEMO_PATH_TOKEN,
@@ -30,11 +30,12 @@ import {
     NuiPopoverModule,
     SrlcStage,
 } from "@nova-ui/bits";
-import { getDemoFiles } from "../../../static/demo-files-factory";
+
 import { ColorPickerBasicExampleComponent } from "./color-picker-basic/color-picker-basic.example.component";
+import { ColorPickerExampleComponent } from "./color-picker-docs/color-picker-docs.example.component";
 import { ColorPickerPaletteExampleComponent } from "./color-picker-palette/color-picker-palette.example.component";
 import { ColorPickerSelectExampleComponent } from "./color-picker-select/color-picker-select.example.component";
-import { ColorPickerExampleComponent } from "./color-picker-docs/color-picker-docs.example.component";
+import { getDemoFiles } from "../../../static/demo-files-factory";
 
 const routes = [
     {

--- a/packages/bits/src/common/directives/dragdrop/drag-and-drop.service.ts
+++ b/packages/bits/src/common/directives/dragdrop/drag-and-drop.service.ts
@@ -71,7 +71,7 @@ export class DragAndDropService {
             event.dataTransfer?.getData("text/plain");
         try {
             return JSON.parse(payload || "");
-        } catch (e) {
+        } catch (_e) {
             return payload;
         }
     }

--- a/packages/bits/src/common/directives/resize/resize.directive.ts
+++ b/packages/bits/src/common/directives/resize/resize.directive.ts
@@ -32,9 +32,9 @@ import forEach from "lodash/forEach";
 /** @ignore */
 interface IResizeEventQueue {
     events: any[];
-    add(event: Function): void;
+    add(event: () => void): void;
     call(): void;
-    remove(event: Function): void;
+    remove(event: () => void): void;
 }
 /** @ignore */
 interface IResizeElement extends HTMLElement {
@@ -87,7 +87,7 @@ export class ResizeDirective implements AfterViewInit, OnDestroy {
     private resizeEventQueue = class implements IResizeEventQueue {
         public events: any[] = [];
 
-        public add(event: Function) {
+        public add(event: () => void) {
             this.events.push(event);
         }
 
@@ -95,7 +95,7 @@ export class ResizeDirective implements AfterViewInit, OnDestroy {
             forEach(this.events, (event) => event.call());
         }
 
-        public remove(event: Function) {
+        public remove(event: () => void) {
             this.events = filter(
                 this.events,
                 (item: Function) => item !== event

--- a/packages/bits/src/common/directives/resize/resize.directive.ts
+++ b/packages/bits/src/common/directives/resize/resize.directive.ts
@@ -134,7 +134,7 @@ export class ResizeDirective implements AfterViewInit, OnDestroy {
      */
     private attachResizeEvent(
         targetElement: IResizeElement,
-        resizeCallback: Function
+        resizeCallback: () => void
     ): void {
         if (targetElement.resizedAttached) {
             targetElement.resizedAttached.add(resizeCallback);
@@ -234,7 +234,7 @@ export class ResizeDirective implements AfterViewInit, OnDestroy {
      */
     private detachResizeEvent = (
         targetElement: IResizeElement,
-        event: Function
+        event: () => void
     ) => {
         if (targetElement.resizedAttached && typeof event === "function") {
             targetElement.resizedAttached.remove(event);

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.html
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,4 @@
 <div
-    [attr.aria-label]="ariaLabel"
     class="nui-breadcrumb"
     *ngIf="items?.length > 1"
 >

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
@@ -35,7 +35,10 @@ import { BreadcrumbItem } from "./public-api";
     styleUrls: ["./breadcrumb.component.less"],
     templateUrl: "./breadcrumb.component.html",
     encapsulation: ViewEncapsulation.None,
-    host: { "[attr.aria-label]": "ariaLabel" },
+    host: {
+        "[attr.aria-label]": "ariaLabel",
+        "[attr.role]": "'navigation'"
+    },
     standalone: false,
 })
 export class BreadcrumbComponent {

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
@@ -37,7 +37,7 @@ import { BreadcrumbItem } from "./public-api";
     encapsulation: ViewEncapsulation.None,
     host: {
         "[attr.aria-label]": "ariaLabel",
-        "[attr.role]": "'navigation'"
+        "[attr.role]": "'navigation'",
     },
     standalone: false,
 })

--- a/packages/bits/src/lib/checkbox/checkbox.component.ts
+++ b/packages/bits/src/lib/checkbox/checkbox.component.ts
@@ -188,7 +188,7 @@ export class CheckboxComponent
     @ViewChild("checkboxLabel")
     public checkboxLabel: ElementRef;
 
-    private rendererListener: Function;
+    private rendererListener: () => void;
     private sub: Subscription;
 
     private _ariaLabel: string = "Checkbox";

--- a/packages/bits/src/lib/color-picker/color-picker.component.spec.ts
+++ b/packages/bits/src/lib/color-picker/color-picker.component.spec.ts
@@ -18,6 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import { Overlay } from "@angular/cdk/overlay";
 import {
     Component,
     CUSTOM_ELEMENTS_SCHEMA,
@@ -26,11 +27,10 @@ import {
 } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { Overlay } from "@angular/cdk/overlay";
+import { Subject } from "rxjs/internal/Subject";
 
 import { ColorPickerComponent } from "./color-picker.component";
 import { ColorService } from "./color.service";
-import { Subject } from "rxjs/internal/Subject";
 
 
 @Component({

--- a/packages/bits/src/lib/color-picker/color-picker.component.ts
+++ b/packages/bits/src/lib/color-picker/color-picker.component.ts
@@ -34,11 +34,13 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 import { Subject } from "rxjs";
 import { takeUntil, tap } from "rxjs/operators";
-import { ColorService } from "./color.service";
-import { getColorValueByName } from "./../../functions/color.helper";
-import { IPaletteColor } from "./../../constants/color-picker.constants";
-import { getOverlayPositions, IOptionValueObject, IResizeConfig, NuiFormFieldControl, OverlayUtilitiesService } from "../public-api";
+
 import { SelectV2Component } from "../select-v2/select/select-v2.component";
+
+import { ColorService } from "./color.service";
+import { getColorValueByName } from "../../functions/color.helper";
+import { IPaletteColor } from "../../constants/color-picker.constants";
+import { getOverlayPositions, IOptionValueObject, IResizeConfig, NuiFormFieldControl, OverlayUtilitiesService } from "../public-api";
 
 // Left and right paddings of .color-picker-container element
 const CONTAINER_SIDE_PADDINGS_PX: number = 20;
@@ -194,7 +196,7 @@ export class ColorPickerComponent
     public registerOnChange(fn: () => void): void {
         this.onChange = fn;
     }
-    
+
     public registerOnTouched(fn: () => void): void {
         this._onTouched = fn;
     }

--- a/packages/bits/src/lib/color-picker/color-picker.module.ts
+++ b/packages/bits/src/lib/color-picker/color-picker.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from "@angular/core";
 
+import { NuiIconModule } from "../icon/icon.module";
+import { NuiSelectV2Module } from "../select-v2/select-v2.module";
 import { NuiCommonModule } from "../../common/common.module";
 import { ColorPickerComponent } from "./color-picker.component";
-import { NuiSelectV2Module } from "../select-v2/select-v2.module";
-import { NuiIconModule } from "../icon/icon.module";
 
 /**
  * @ignore

--- a/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
@@ -89,12 +89,12 @@ export class DatePickerInnerComponent
     protected _value: Moment | undefined;
     protected _todayDate: Moment = moment();
 
-    protected refreshViewHandlerDay: Function;
-    protected compareHandlerDay: Function;
-    protected refreshViewHandlerMonth: Function;
-    protected compareHandlerMonth: Function;
-    protected refreshViewHandlerYear: Function;
-    protected compareHandlerYear: Function;
+    protected refreshViewHandlerDay: () => void;
+    protected compareHandlerDay: (d1: Moment, d2?: Moment) => number | undefined;
+    protected refreshViewHandlerMonth: () => void;
+    protected compareHandlerMonth: (d1: Moment, d2?: Moment) => number | undefined;
+    protected refreshViewHandlerYear: () => void;
+    protected compareHandlerYear: (d1: Moment, d2?: Moment) => number | undefined;
 
     private modes: string[] = ["day", "month", "year"];
 
@@ -179,7 +179,10 @@ export class DatePickerInnerComponent
         return shouldRefreshView;
     }
 
-    public setCompareHandler(handler: Function, type: string): void {
+    public setCompareHandler(
+        handler: (d1: Moment, d2?: Moment) => number | undefined,
+        type: string
+    ): void {
         if (type === "day") {
             this.compareHandlerDay = handler;
         }
@@ -210,7 +213,7 @@ export class DatePickerInnerComponent
             return this.compareHandlerYear(date1, date2);
         }
 
-        return void 0;
+        return void 0;() => void
     }
 
     public setRefreshViewHandler(handler: Function, type: string): void {

--- a/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
@@ -90,11 +90,11 @@ export class DatePickerInnerComponent
     protected _todayDate: Moment = moment();
 
     protected refreshViewHandlerDay: () => void;
-    protected compareHandlerDay: (d1: Moment, d2?: Moment) => number | undefined;
+    protected compareHandlerDay: (d1: Moment, d2: Moment) => number | undefined;
     protected refreshViewHandlerMonth: () => void;
-    protected compareHandlerMonth: (d1: Moment, d2?: Moment) => number | undefined;
+    protected compareHandlerMonth: (d1: Moment, d2: Moment) => number | undefined;
     protected refreshViewHandlerYear: () => void;
-    protected compareHandlerYear: (d1: Moment, d2?: Moment) => number | undefined;
+    protected compareHandlerYear: (d1: Moment, d2: Moment) => number | undefined;
 
     private modes: string[] = ["day", "month", "year"];
 
@@ -180,7 +180,7 @@ export class DatePickerInnerComponent
     }
 
     public setCompareHandler(
-        handler: (d1: Moment, d2?: Moment) => number | undefined,
+        handler: (d1: Moment, d2: Moment) => number | undefined,
         type: string
     ): void {
         if (type === "day") {
@@ -213,10 +213,10 @@ export class DatePickerInnerComponent
             return this.compareHandlerYear(date1, date2);
         }
 
-        return void 0;() => void
+        return void 0;
     }
 
-    public setRefreshViewHandler(handler: Function, type: string): void {
+    public setRefreshViewHandler(handler: () => void, type: string): void {
         if (type === "day") {
             this.refreshViewHandlerDay = handler;
         }

--- a/packages/bits/src/lib/dialog/dialog.component.ts
+++ b/packages/bits/src/lib/dialog/dialog.component.ts
@@ -18,7 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { CdkScrollable, ScrollDispatcher } from "@angular/cdk/scrolling";
+import { CdkScrollable } from "@angular/cdk/scrolling";
 import { DOCUMENT } from "@angular/common";
 import {
     AfterViewInit,

--- a/packages/bits/src/lib/image/image.component.ts
+++ b/packages/bits/src/lib/image/image.component.ts
@@ -135,7 +135,7 @@ export class ImageComponent implements OnInit, AfterViewInit, OnChanges {
                 const svg = this.el.nativeElement.querySelector("svg");
                 svg.setAttribute("width", "100%");
                 svg.setAttribute("height", "100%");
-            } catch (_e) {
+            } catch {
                 console.warn(
                     "Can't apply 'autoFill' to nui-image, because it is only applicable to SVG type of images"
                 );

--- a/packages/bits/src/lib/image/image.component.ts
+++ b/packages/bits/src/lib/image/image.component.ts
@@ -135,7 +135,7 @@ export class ImageComponent implements OnInit, AfterViewInit, OnChanges {
                 const svg = this.el.nativeElement.querySelector("svg");
                 svg.setAttribute("width", "100%");
                 svg.setAttribute("height", "100%");
-            } catch (e) {
+            } catch (_e) {
                 console.warn(
                     "Can't apply 'autoFill' to nui-image, because it is only applicable to SVG type of images"
                 );

--- a/packages/bits/src/lib/menu/menu/menu.component.html
+++ b/packages/bits/src/lib/menu/menu/menu.component.html
@@ -22,7 +22,7 @@
     >
         <span>{{ title }}</span>
     </button>
-    <div popupAreaContent>
+    <div popupAreaContent role="menu">
         <nui-menu-popup
             *ngIf="itemsSource"
             [itemsSource]="itemsSource"

--- a/packages/bits/src/lib/paginator/paginator.component.html
+++ b/packages/bits/src/lib/paginator/paginator.component.html
@@ -2,11 +2,10 @@
     <div class="nui-paginator__items">
         <ul
             class="nui-paginator__list"
-            role="listbox"
+            role="list"
             aria-label="List of pages"
         >
             <li
-                role="option"
                 title="{{ item.title }}"
                 [ngClass]="item.style"
                 *ngFor="let item of itemsList"

--- a/packages/bits/src/lib/search/search.component.html
+++ b/packages/bits/src/lib/search/search.component.html
@@ -32,6 +32,7 @@
             [placeholder]="getPlaceholder()"
             (keyup)="onKeyup($event)"
             [attr.aria-invalid]="isInErrorState"
+            aria-label="Search"
         />
     </div>
 </div>

--- a/packages/bits/src/lib/table/table-state-handler.service.spec.ts
+++ b/packages/bits/src/lib/table/table-state-handler.service.spec.ts
@@ -19,6 +19,7 @@
 //  THE SOFTWARE.
 
 import { NgZone } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
 
 import { TableSpecHelpers } from "./table-spec-helpers/table-spec-helpers";
 import {
@@ -91,10 +92,13 @@ describe("services >", () => {
         let serviceInstance: TableStateHandlerService;
 
         beforeEach(() => {
-            serviceInstance = new TableStateHandlerService(
-                NgZone as any,
-                SelectorService as any
-            );
+            TestBed.configureTestingModule({
+                providers: [
+                    TableStateHandlerService,
+                    { provide: SelectorService, useValue: {} },
+                ],
+            });
+            serviceInstance = TestBed.inject(TableStateHandlerService);
             serviceInstance.tableColumns = ["first", "second", "third"];
         });
 

--- a/packages/bits/src/lib/table/table-state-handler.service.ts
+++ b/packages/bits/src/lib/table/table-state-handler.service.ts
@@ -20,7 +20,7 @@
 
 import {
     forwardRef,
-    Inject,
+    inject,
     Injectable,
     NgZone,
     TrackByFunction,
@@ -144,11 +144,10 @@ export class TableStateHandlerService {
         desc: "triangle-down",
     };
 
-    constructor(
-        protected zone: NgZone,
-        @Inject(forwardRef(() => SelectorService))
-        protected selectorService: SelectorService
-    ) {}
+    protected zone = inject(NgZone);
+    protected selectorService = inject(SelectorService);
+
+    constructor() {}
 
     /**
      * Used to sync directives and components in table to apply additional styles and logic

--- a/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
+++ b/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
@@ -383,6 +383,8 @@ export class TableStickyHeaderDirective implements AfterViewInit, OnDestroy {
             this.renderer.addClass(this.stickyHeadContainer, cssClass)
         );
 
+        this.renderer.setAttribute(this.stickyHeadContainer, "role", "table");
+
         this.renderer.insertBefore(
             this.viewportEl.parentElement,
             wrapper,

--- a/packages/bits/src/lib/table/table-virtual-scroll/table-virtual-scroll-strategy.ts
+++ b/packages/bits/src/lib/table/table-virtual-scroll/table-virtual-scroll-strategy.ts
@@ -67,7 +67,7 @@ export class TableVirtualScrollLinearStrategy implements VirtualScrollStrategy {
 
     public onRenderedOffsetChanged(): void {}
 
-    public scrollToIndex(index: number, behavior: ScrollBehavior): void {}
+    public scrollToIndex(_index: number, _behavior: ScrollBehavior): void {}
 
     /**
      * Sets the size of the items in the virtually scrolling list.
@@ -198,7 +198,7 @@ export class TableVirtualScrollStrategy implements VirtualScrollStrategy {
 
     public onRenderedOffsetChanged(): void {}
 
-    public scrollToIndex(index: number, behavior: ScrollBehavior): void {}
+    public scrollToIndex(_index: number, _behavior: ScrollBehavior): void {}
 
     /**
      * Sets the size of the items in the virtually scrolling list.

--- a/packages/bits/src/lib/table/table-virtual-scroll/table-virtual-scroll.directive.ts
+++ b/packages/bits/src/lib/table/table-virtual-scroll/table-virtual-scroll.directive.ts
@@ -65,11 +65,11 @@ export class TableVirtualScrollLinearDirective implements OnChanges {
     );
 
     public ngOnChanges(
-        changes: ComponentChanges<TableVirtualScrollLinearDirective>
+        _changes: ComponentChanges<TableVirtualScrollLinearDirective>
     ): void {
         this.scrollStrategy.setRowHeight(+this.rowHeight);
 
-        if (changes.rowCount) {
+        if (_changes.rowCount) {
             this.updateDataLength(this.rowCount);
         }
     }

--- a/packages/bits/src/services/data-source/data-source.service.ts
+++ b/packages/bits/src/services/data-source/data-source.service.ts
@@ -41,7 +41,7 @@ import {
 export abstract class DataSourceService<
     T,
     F extends IFilters = IFilters,
-    D = any
+    _D = any
 > extends DataSource<T> {
     public dataSubject: BehaviorSubject<T[]>;
     public outputsSubject: Subject<IFilteringOutputs>;

--- a/packages/bits/src/styles/nui-framework-colors.less
+++ b/packages/bits/src/styles/nui-framework-colors.less
@@ -71,7 +71,7 @@
     10%
 ); // unofficial
 @nui-color-text-secondary: fade(@black, 60%);
-@nui-color-text-link: @primary_blue;
+@nui-color-text-link: shade(@primary_blue, 15%);
 @nui-color-text-link-inverse: tint(@primary_blue, 30%);
 @nui-color-text-disabled: fade(@black, 30%);
 @nui-color-text-light: @white;
@@ -99,7 +99,7 @@
 @nui-color-line-active: @primary_blue;
 @nui-color-line-critical: @critical_red;
 @nui-color-line-warning: @warning_yellow;
-@nui-color-line-info: @info_blue;
+@nui-color-line-info: shade(@info_blue, 10%);
 @nui-color-line-ok: @ok_green;
 @nui-color-line-ok-secondary: fade(@ok_green, 40%);
 @nui-color-line-ok-secondary-hover: fade(@ok_green, 50%);
@@ -342,17 +342,17 @@
 
 /* classifications */
 /* SECTION: classifications */
-@nui-color-classification-one: @white; 
-@nui-color-classification-two: @swi_gray; 
-@nui-color-classification-three: @black; 
-@nui-color-classification-four: @ok_green; 
-@nui-color-classification-five: @swi_green; 
-@nui-color-classification-six: @swi_yellow; 
-@nui-color-classification-seven: @swi_orange; 
-@nui-color-classification-eight: @chart-orange; 
-@nui-color-classification-nine: @critical_red; 
-@nui-color-classification-ten: @chart-pink; 
-@nui-color-classification-eleven: @chart-violet; 
-@nui-color-classification-twelve: @chart-violet-dark; 
-@nui-color-classification-thirteen: @chart-blue-dark; 
+@nui-color-classification-one: @white;
+@nui-color-classification-two: @swi_gray;
+@nui-color-classification-three: @black;
+@nui-color-classification-four: @ok_green;
+@nui-color-classification-five: @swi_green;
+@nui-color-classification-six: @swi_yellow;
+@nui-color-classification-seven: @swi_orange;
+@nui-color-classification-eight: @chart-orange;
+@nui-color-classification-nine: @critical_red;
+@nui-color-classification-ten: @chart-pink;
+@nui-color-classification-eleven: @chart-violet;
+@nui-color-classification-twelve: @chart-violet-dark;
+@nui-color-classification-thirteen: @chart-blue-dark;
 @nui-color-classification-fourteen: @primary_blue;

--- a/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.html
+++ b/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.html
@@ -41,6 +41,8 @@
                     class="nui-text-widget nui-widget__header__content-title"
                     [title]="title"
                     *ngIf="!url || editMode"
+                    role="heading"
+                    aria-level="2"
                 >
                     {{ title }}
                 </div>
@@ -56,6 +58,8 @@
                         "
                         class="nui-text-widget nui-widget__header__content-title"
                         [nuiTooltip]="linkTooltip"
+                        role="heading"
+                        aria-level="2"
                         >{{ title }}</a
                     >
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3993,9 +3993,9 @@ ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-angular-gridster2@19.0.0:
+angular-gridster2@^19.0.0:
   version "19.0.0"
-  resolved "https://registry.yarnpkg.com/angular-gridster2/-/angular-gridster2-19.0.0.tgz#39aaad9ed1cb5f480cdd6adedfa9e73bf64c59b6"
+  resolved "https://registry.npmjs.org/angular-gridster2/-/angular-gridster2-19.0.0.tgz#39aaad9ed1cb5f480cdd6adedfa9e73bf64c59b6"
   integrity sha512-82SHZzwOmGRvR77VtbpV5Eh7CoTtxLslwOVzTYB3qNQIGGFaOsS8nRAuYpZOlZpVc+n6fBz1HU0yP0icnQ9ppg==
   dependencies:
     tslib "^2.4.0"


### PR DESCRIPTION
## Frontend Pull Request Description
Fixed AxeDevTool accessibility requirements on home summary page issues.

<!-- Provide a brief summary of the changes made in the frontend project. -->
Jiras:
https://swicloud.atlassian.net/browse/OO-50765
https://swicloud.atlassian.net/browse/OO-50699
https://swicloud.atlassian.net/browse/OO-50862
https://swicloud.atlassian.net/browse/OO-50565
https://swicloud.atlassian.net/browse/OO-50701
https://swicloud.atlassian.net/browse/OO-50786
https://swicloud.atlassian.net/browse/OO-59252
https://swicloud.atlassian.net/browse/OO-50766

Before:
<img width="1916" height="816" alt="image" src="https://github.com/user-attachments/assets/ff7be637-03eb-4c39-a118-f578705196a0" />

After fix:
<img width="1919" height="839" alt="image" src="https://github.com/user-attachments/assets/5324779a-8b05-4267-9099-11b88d1bc638" />

**Banner contrast:**
<img width="1006" height="341" alt="image" src="https://github.com/user-attachments/assets/17d8632f-27e7-479c-8d41-92c9db9eec1f" />

**Action button contrast**
<img width="494" height="343" alt="image" src="https://github.com/user-attachments/assets/4ac245ac-c327-434d-82e9-c7c2099d9761" />


## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
