### PR TITLE
Fixed few Accessibility requirements on new Home Summary Page issues

### DIFF
--- a/packages/bits/demo/src/components/demo/color-picker/color-picker-basic/color-picker-basic.example.component.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker-basic/color-picker-basic.example.component.ts
@@ -18,7 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import {
     FormBuilder,
     FormControl,
@@ -45,7 +45,7 @@ const CHART_PALETTE_CS1: string[] = [
     styles: [],
     standalone: false,
 })
-export class ColorPickerBasicExampleComponent {
+export class ColorPickerBasicExampleComponent implements OnInit {
     public myForm: FormGroup<{ backgroundColor: FormControl<string | null> }>;
     public colors: string[] = CHART_PALETTE_CS1;
     

--- a/packages/bits/demo/src/components/demo/color-picker/color-picker-palette/color-picker-palette.example.component.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker-palette/color-picker-palette.example.component.ts
@@ -18,12 +18,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import {
     FormBuilder,
     FormControl,
     FormGroup,
 } from "@angular/forms";
+
 import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/color-picker.constants";
 
 
@@ -33,7 +34,7 @@ import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/colo
     styles: [],
     standalone: false,
 })
-export class ColorPickerPaletteExampleComponent {
+export class ColorPickerPaletteExampleComponent implements OnInit {
     public myForm: FormGroup<{ backgroundColor: FormControl<string | null> }>;
     public colorPalette: IPaletteColor[] = Array.from(HTML_COLORS.entries())
     .map(([label, color]) => ({label,color}));

--- a/packages/bits/demo/src/components/demo/color-picker/color-picker-select/color-picker-select.example.component.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker-select/color-picker-select.example.component.ts
@@ -18,12 +18,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import {
     FormBuilder,
     FormControl,
     FormGroup,
 } from "@angular/forms";
+
 import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/color-picker.constants";
 
 
@@ -33,7 +34,7 @@ import { HTML_COLORS, IPaletteColor } from "../../../../../../src/constants/colo
     styles: [],
     standalone: false,
 })
-export class ColorPickerSelectExampleComponent {
+export class ColorPickerSelectExampleComponent implements OnInit {
     public myForm: FormGroup<{ backgroundColor: FormControl<string | null> }>;
     public colorPalette: IPaletteColor[] = Array.from(HTML_COLORS.entries())
     .map(([label, color]) => ({label,color}));

--- a/packages/bits/demo/src/components/demo/color-picker/color-picker.module.ts
+++ b/packages/bits/demo/src/components/demo/color-picker/color-picker.module.ts
@@ -19,8 +19,8 @@
 //  THE SOFTWARE.
 
 import { NgModule } from "@angular/core";
-import { RouterModule } from "@angular/router";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { RouterModule } from "@angular/router";
 
 import {
     DEMO_PATH_TOKEN,
@@ -30,11 +30,12 @@ import {
     NuiPopoverModule,
     SrlcStage,
 } from "@nova-ui/bits";
-import { getDemoFiles } from "../../../static/demo-files-factory";
+
 import { ColorPickerBasicExampleComponent } from "./color-picker-basic/color-picker-basic.example.component";
+import { ColorPickerExampleComponent } from "./color-picker-docs/color-picker-docs.example.component";
 import { ColorPickerPaletteExampleComponent } from "./color-picker-palette/color-picker-palette.example.component";
 import { ColorPickerSelectExampleComponent } from "./color-picker-select/color-picker-select.example.component";
-import { ColorPickerExampleComponent } from "./color-picker-docs/color-picker-docs.example.component";
+import { getDemoFiles } from "../../../static/demo-files-factory";
 
 const routes = [
     {

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.html
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,4 @@
 <div
-    [attr.aria-label]="ariaLabel"
     class="nui-breadcrumb"
     *ngIf="items?.length > 1"
 >

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
@@ -35,7 +35,10 @@ import { BreadcrumbItem } from "./public-api";
     styleUrls: ["./breadcrumb.component.less"],
     templateUrl: "./breadcrumb.component.html",
     encapsulation: ViewEncapsulation.None,
-    host: { "[attr.aria-label]": "ariaLabel" },
+    host: {
+        "[attr.aria-label]": "ariaLabel",
+        "[attr.role]": "'navigation'"
+    },
     standalone: false,
 })
 export class BreadcrumbComponent {

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
@@ -37,7 +37,7 @@ import { BreadcrumbItem } from "./public-api";
     encapsulation: ViewEncapsulation.None,
     host: {
         "[attr.aria-label]": "ariaLabel",
-        "[attr.role]": "'navigation'"
+        "[attr.role]": "'navigation'",
     },
     standalone: false,
 })

--- a/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/packages/bits/src/lib/breadcrumb/breadcrumb.component.ts
@@ -36,8 +36,8 @@ import { BreadcrumbItem } from "./public-api";
     templateUrl: "./breadcrumb.component.html",
     encapsulation: ViewEncapsulation.None,
     host: {
-        "[attr.aria-label]": "ariaLabel",
-        "[attr.role]": "'navigation'",
+        "[attr.aria-label]": "items?.length > 1 ? ariaLabel : null",
+        "[attr.role]": "items?.length > 1 ? 'navigation' : null",
     },
     standalone: false,
 })

--- a/packages/bits/src/lib/menu/menu/menu.component.html
+++ b/packages/bits/src/lib/menu/menu/menu.component.html
@@ -22,7 +22,7 @@
     >
         <span>{{ title }}</span>
     </button>
-    <div popupAreaContent>
+    <div popupAreaContent role="menu">
         <nui-menu-popup
             *ngIf="itemsSource"
             [itemsSource]="itemsSource"

--- a/packages/bits/src/lib/menu/menu/menu.component.html
+++ b/packages/bits/src/lib/menu/menu/menu.component.html
@@ -10,7 +10,7 @@
         nui-button
         nuiPopupToggle
         [disabled]="isDisabled"
-        aria-haspopup="true"
+        aria-haspopup="menu"
         type="button"
         (blur)="onBlur($event)"
         [displayStyle]="displayStyle"

--- a/packages/bits/src/lib/overlay/overlay-component/overlay.component.ts
+++ b/packages/bits/src/lib/overlay/overlay-component/overlay.component.ts
@@ -67,7 +67,7 @@ const isMouseEvent = (event: Event): event is MouseEvent =>
             id="nui-overlay"
             class="nui-overlay"
             [attr.role]="roleAttr || null"
-            [attr.aria-label]="ariaLabel || null"
+            [attr.aria-labelledby]="ariaLabelledBy || null"
             [ngClass]="{ empty: empty$ | async }"
         >
             <ng-content></ng-content>
@@ -107,8 +107,8 @@ export class OverlayComponent
     /** Sets the role attribute */
     @Input() roleAttr: string;
 
-    /** Sets the aria-label attribute for accessibility */
-    @Input() ariaLabel?: string;
+    /** Sets the aria-labelledby attribute for accessibility */
+    @Input() ariaLabelledBy?: string;
 
     /** Emits MouseEvent when click occurs outside Select/Combobox */
     @Output() public readonly clickOutside = new EventEmitter<MouseEvent>();

--- a/packages/bits/src/lib/overlay/overlay-component/overlay.component.ts
+++ b/packages/bits/src/lib/overlay/overlay-component/overlay.component.ts
@@ -67,6 +67,7 @@ const isMouseEvent = (event: Event): event is MouseEvent =>
             id="nui-overlay"
             class="nui-overlay"
             [attr.role]="roleAttr || null"
+            [attr.aria-label]="ariaLabel || roleAttr || null"
             [ngClass]="{ empty: empty$ | async }"
         >
             <ng-content></ng-content>
@@ -105,6 +106,9 @@ export class OverlayComponent
 
     /** Sets the role attribute */
     @Input() roleAttr: string;
+
+    /** Sets the aria-label attribute for accessibility */
+    @Input() ariaLabel: string;
 
     /** Emits MouseEvent when click occurs outside Select/Combobox */
     @Output() public readonly clickOutside = new EventEmitter<MouseEvent>();

--- a/packages/bits/src/lib/overlay/overlay-component/overlay.component.ts
+++ b/packages/bits/src/lib/overlay/overlay-component/overlay.component.ts
@@ -67,7 +67,7 @@ const isMouseEvent = (event: Event): event is MouseEvent =>
             id="nui-overlay"
             class="nui-overlay"
             [attr.role]="roleAttr || null"
-            [attr.aria-label]="ariaLabel || roleAttr || null"
+            [attr.aria-label]="ariaLabel || null"
             [ngClass]="{ empty: empty$ | async }"
         >
             <ng-content></ng-content>
@@ -108,7 +108,7 @@ export class OverlayComponent
     @Input() roleAttr: string;
 
     /** Sets the aria-label attribute for accessibility */
-    @Input() ariaLabel: string;
+    @Input() ariaLabel?: string;
 
     /** Emits MouseEvent when click occurs outside Select/Combobox */
     @Output() public readonly clickOutside = new EventEmitter<MouseEvent>();

--- a/packages/bits/src/lib/paginator/paginator.component.html
+++ b/packages/bits/src/lib/paginator/paginator.component.html
@@ -2,11 +2,10 @@
     <div class="nui-paginator__items">
         <ul
             class="nui-paginator__list"
-            role="listbox"
+            role="list"
             aria-label="List of pages"
         >
             <li
-                role="option"
                 title="{{ item.title }}"
                 [ngClass]="item.style"
                 *ngFor="let item of itemsList"

--- a/packages/bits/src/lib/paginator/paginator.component.html
+++ b/packages/bits/src/lib/paginator/paginator.component.html
@@ -1,9 +1,10 @@
 <div class="nui-paginator" *ngIf="showPaginator()">
     <div class="nui-paginator__items">
+        <nav aria-label="Pagination" i18n-aria-label>
         <ul
             class="nui-paginator__list"
-            role="list"
             aria-label="List of pages"
+            i18n-aria-label
         >
             <li
                 title="{{ item.title }}"
@@ -43,7 +44,7 @@
                         displayStyle="action"
                         [ngClass]="item.imageClass"
                         [isEmpty]="false"
-                        aria-haspopup="true"
+                        aria-haspopup="menu"
                         (click)="handleDotsClick()"
                         class="nui-paginator__dots"
                     >
@@ -95,6 +96,7 @@
                 </nui-popup>
             </li>
         </ul>
+        </nav>
     </div>
     <div class="nui-paginator__options">
         <div class="nui-paginator__info" i18n>

--- a/packages/bits/src/lib/radio/radio-group.component.ts
+++ b/packages/bits/src/lib/radio/radio-group.component.ts
@@ -52,7 +52,7 @@ import { NuiFormFieldControl } from "../form-field/public-api";
  */
 @Component({
     selector: "nui-radio-group",
-    template: `<div class="nui-radio-group" [attr.aria-label]="ariaLabel">
+    template: `<div class="nui-radio-group">
         <ng-content></ng-content>
     </div>`,
     providers: [
@@ -67,7 +67,7 @@ import { NuiFormFieldControl } from "../form-field/public-api";
             multi: true,
         },
     ],
-    host: { role: "radiogroup" },
+    host: { role: "radiogroup", "[attr.aria-label]": "ariaLabel || null" },
     standalone: false,
 })
 export class RadioGroupComponent
@@ -221,7 +221,6 @@ export class RadioGroupComponent
     host: {
         "[class.nui-radio--hovered]": "hovered",
         "[class.nui-radio--checked]": "checked",
-        role: "radio",
     },
     standalone: false,
 })

--- a/packages/bits/src/lib/radio/radio.component.html
+++ b/packages/bits/src/lib/radio/radio.component.html
@@ -16,7 +16,7 @@
                 [value]="value"
                 [checked]="checked"
                 [disabled]="disabled"
-                [attr.aria-label]="ariaLabel"
+                [attr.aria-label]="ariaLabel || null"
                 [attr.aria-checked]="checked"
                 (change)="changeHandler()"
                 (click)="onInputClick($event)"

--- a/packages/bits/src/lib/search/search.component.html
+++ b/packages/bits/src/lib/search/search.component.html
@@ -32,6 +32,7 @@
             [placeholder]="getPlaceholder()"
             (keyup)="onKeyup($event)"
             [attr.aria-invalid]="isInErrorState"
+            aria-label="Search"
         />
     </div>
 </div>

--- a/packages/bits/src/lib/search/search.component.html
+++ b/packages/bits/src/lib/search/search.component.html
@@ -33,6 +33,7 @@
             (keyup)="onKeyup($event)"
             [attr.aria-invalid]="isInErrorState"
             aria-label="Search"
+            i18n-aria-label
         />
     </div>
 </div>

--- a/packages/bits/src/lib/select-v2/base-select-v2.ts
+++ b/packages/bits/src/lib/select-v2/base-select-v2.ts
@@ -87,6 +87,8 @@ export abstract class BaseSelectV2
         OnDestroy,
         OnChanges
 {
+    private static _counter = 0;
+
     /** Value used as a placeholder for the select. */
     @Input() public placeholder: string = "";
 
@@ -195,7 +197,6 @@ export abstract class BaseSelectV2
 
     /** Unique ID for the trigger element, used for aria-labelledby on the overlay */
     public readonly triggerId = `nui-select-trigger-${BaseSelectV2._counter++}`;
-    private static _counter = 0;
     private virtualScrollResizeObserver: ResizeObserver;
 
     /** Emits value which has been selected */

--- a/packages/bits/src/lib/select-v2/base-select-v2.ts
+++ b/packages/bits/src/lib/select-v2/base-select-v2.ts
@@ -192,6 +192,10 @@ export abstract class BaseSelectV2
     private _selectedOptions: SelectV2OptionComponent[] = [];
 
     private _ariaLabel: string = "";
+
+    /** Unique ID for the trigger element, used for aria-labelledby on the overlay */
+    public readonly triggerId = `nui-select-trigger-${BaseSelectV2._counter++}`;
+    private static _counter = 0;
     private virtualScrollResizeObserver: ResizeObserver;
 
     /** Emits value which has been selected */

--- a/packages/bits/src/lib/select-v2/combobox-v2/combobox-v2.component.html
+++ b/packages/bits/src/lib/select-v2/combobox-v2/combobox-v2.component.html
@@ -45,6 +45,7 @@
 ></button>
 <nui-overlay
     roleAttr="listbox"
+    [ariaLabel]="ariaLabel"
     [toggleReference]="elRef.nativeElement"
     [viewportMargin]="popupViewportMargin"
     [overlayConfig]="overlayConfig"

--- a/packages/bits/src/lib/select-v2/combobox-v2/combobox-v2.component.html
+++ b/packages/bits/src/lib/select-v2/combobox-v2/combobox-v2.component.html
@@ -7,6 +7,7 @@
     <input
         class="nui-combobox-v2__input pb-2"
         type="text"
+        [id]="triggerId"
         [attr.aria-label]="ariaLabel || 'input'"
         [class.has-error]="isInErrorState"
         [disabled]="isDisabled"
@@ -45,7 +46,7 @@
 ></button>
 <nui-overlay
     roleAttr="listbox"
-    [ariaLabel]="ariaLabel"
+    [ariaLabelledBy]="triggerId"
     [toggleReference]="elRef.nativeElement"
     [viewportMargin]="popupViewportMargin"
     [overlayConfig]="overlayConfig"

--- a/packages/bits/src/lib/select-v2/select/select-v2.component.html
+++ b/packages/bits/src/lib/select-v2/select/select-v2.component.html
@@ -30,6 +30,7 @@
 </div>
 <nui-overlay
     roleAttr="listbox"
+    [ariaLabel]="ariaLabel"
     [toggleReference]="elRef.nativeElement"
     [viewportMargin]="popupViewportMargin"
     [overlayConfig]="overlayConfig"

--- a/packages/bits/src/lib/select-v2/select/select-v2.component.html
+++ b/packages/bits/src/lib/select-v2/select/select-v2.component.html
@@ -1,6 +1,7 @@
 <div
     tabindex="0"
     #input
+    [id]="triggerId"
     class="nui-select-v2__container"
     [attr.aria-label]="ariaLabel"
     (keydown)="onKeyDown($event)"
@@ -30,7 +31,7 @@
 </div>
 <nui-overlay
     roleAttr="listbox"
-    [ariaLabel]="ariaLabel"
+    [ariaLabelledBy]="triggerId"
     [toggleReference]="elRef.nativeElement"
     [viewportMargin]="popupViewportMargin"
     [overlayConfig]="overlayConfig"

--- a/packages/bits/src/lib/switch/switch.component.html
+++ b/packages/bits/src/lib/switch/switch.component.html
@@ -13,7 +13,8 @@
             tabindex="{{ disabled ? -1 : 0 }}"
             role="checkbox"
             [attr.aria-checked]="value"
-            [attr.aria-label]="ariaLabel"
+            [attr.aria-label]="ariaLabel || null"
+            [attr.aria-labelledby]="ariaLabel ? null : labelId"
         >
             <div class="nui-switch__on">
                 <svg
@@ -35,7 +36,7 @@
                 ></svg>
             </div>
         </div>
-        <label class="nui-switch__label">
+        <label class="nui-switch__label" [attr.id]="labelId">
             <ng-content></ng-content>
         </label>
     </div>

--- a/packages/bits/src/lib/switch/switch.component.spec.ts
+++ b/packages/bits/src/lib/switch/switch.component.spec.ts
@@ -71,5 +71,38 @@ describe("components >", () => {
                 expect(touched).not.toHaveBeenCalled();
             });
         });
+
+        describe("accessibility >", () => {
+            it("should set aria-labelledby when ariaLabel is not provided", () => {
+                switchFixture.detectChanges();
+
+                const switchBar = switchFixture.nativeElement.querySelector(
+                    ".nui-switch__bar"
+                ) as HTMLElement;
+                const label = switchFixture.nativeElement.querySelector(
+                    ".nui-switch__label"
+                ) as HTMLElement;
+
+                expect(switchBar.getAttribute("aria-label")).toBeNull();
+                expect(switchBar.getAttribute("aria-labelledby")).toBe(
+                    label.getAttribute("id")
+                );
+                expect(label.getAttribute("id")).toContain("nui-switch-label-");
+            });
+
+            it("should set aria-label when ariaLabel is provided", () => {
+                nuiSwitch.ariaLabel = "Refresh widget periodically";
+                switchFixture.detectChanges();
+
+                const switchBar = switchFixture.nativeElement.querySelector(
+                    ".nui-switch__bar"
+                ) as HTMLElement;
+
+                expect(switchBar.getAttribute("aria-label")).toBe(
+                    "Refresh widget periodically"
+                );
+                expect(switchBar.getAttribute("aria-labelledby")).toBeNull();
+            });
+        });
     });
 });

--- a/packages/bits/src/lib/switch/switch.component.ts
+++ b/packages/bits/src/lib/switch/switch.component.ts
@@ -31,6 +31,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
 import { NuiFormFieldControl } from "../form-field/public-api";
 
+let switchLabelCounter = 0;
+
 /**
  * <example-url>./../examples/index.html#/switch</example-url>
  */
@@ -60,7 +62,12 @@ export class SwitchComponent implements OnInit, ControlValueAccessor {
     /**
      * Input to set aria label text
      */
-    @Input() public ariaLabel: string = "Switch";
+    @Input() public ariaLabel?: string;
+
+    /**
+     * Label element id used to dynamically compute accessible name.
+     */
+    public readonly labelId = `nui-switch-label-${switchLabelCounter++}`;
 
     @Output() valueChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 

--- a/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
+++ b/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
@@ -383,6 +383,8 @@ export class TableStickyHeaderDirective implements AfterViewInit, OnDestroy {
             this.renderer.addClass(this.stickyHeadContainer, cssClass)
         );
 
+        this.renderer.setAttribute(this.stickyHeadContainer, "role", "table");
+
         this.renderer.insertBefore(
             this.viewportEl.parentElement,
             wrapper,

--- a/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
+++ b/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
@@ -383,7 +383,7 @@ export class TableStickyHeaderDirective implements AfterViewInit, OnDestroy {
             this.renderer.addClass(this.stickyHeadContainer, cssClass)
         );
 
-        this.renderer.setAttribute(this.stickyHeadContainer, "role", "table");
+        this.renderer.setAttribute(this.stickyHeadContainer, "aria-hidden", "true");
 
         this.renderer.insertBefore(
             this.viewportEl.parentElement,
@@ -407,8 +407,11 @@ export class TableStickyHeaderDirective implements AfterViewInit, OnDestroy {
 
         const theadPlaceholder: Node = this.headRef.cloneNode(true);
 
-        // Note: making header invisible
-        this.renderer.setStyle(theadPlaceholder, "visibility", "collapse");
+        // Note: Visually hiding the placeholder but keeping it accessible to screen readers.
+        // cdk-visually-hidden uses position:absolute which removes it from table layout
+        // (no visual double-header) while keeping it in the accessibility tree so
+        // screen readers can announce proper column headers within the original table.
+        this.renderer.addClass(theadPlaceholder, "cdk-visually-hidden");
         // Note: Adding an identifier for the header placeholder to avoid confusion
         this.renderer.addClass(theadPlaceholder, "sticky-header-placeholder");
         // Note: Appending head placeholder to the table

--- a/packages/bits/src/styles/nui-framework-colors-dark.less
+++ b/packages/bits/src/styles/nui-framework-colors-dark.less
@@ -90,7 +90,7 @@
 @nui-color-line-active: @primary-blue--dark;
 @nui-color-line-critical: @critical_red--dark;
 @nui-color-line-warning: @warning_yellow;
-@nui-color-line-info: @info_blue;
+@nui-color-line-info: shade(@info_blue, 10%);
 @nui-color-line-ok: @ok_green;
 @nui-color-line-ok-secondary: fade(@ok_green, 30%);
 @nui-color-line-ok-secondary-hover: fade(@ok_green, 40%);

--- a/packages/bits/src/styles/nui-framework-colors.less
+++ b/packages/bits/src/styles/nui-framework-colors.less
@@ -71,7 +71,7 @@
     10%
 ); // unofficial
 @nui-color-text-secondary: fade(@black, 60%);
-@nui-color-text-link: @primary_blue;
+@nui-color-text-link: shade(@primary_blue, 15%);
 @nui-color-text-link-inverse: tint(@primary_blue, 30%);
 @nui-color-text-disabled: fade(@black, 30%);
 @nui-color-text-light: @white;
@@ -99,7 +99,7 @@
 @nui-color-line-active: @primary_blue;
 @nui-color-line-critical: @critical_red;
 @nui-color-line-warning: @warning_yellow;
-@nui-color-line-info: @info_blue;
+@nui-color-line-info: shade(@info_blue, 10%);
 @nui-color-line-ok: @ok_green;
 @nui-color-line-ok-secondary: fade(@ok_green, 40%);
 @nui-color-line-ok-secondary-hover: fade(@ok_green, 50%);
@@ -342,17 +342,17 @@
 
 /* classifications */
 /* SECTION: classifications */
-@nui-color-classification-one: @white; 
-@nui-color-classification-two: @swi_gray; 
-@nui-color-classification-three: @black; 
-@nui-color-classification-four: @ok_green; 
-@nui-color-classification-five: @swi_green; 
-@nui-color-classification-six: @swi_yellow; 
-@nui-color-classification-seven: @swi_orange; 
-@nui-color-classification-eight: @chart-orange; 
-@nui-color-classification-nine: @critical_red; 
-@nui-color-classification-ten: @chart-pink; 
-@nui-color-classification-eleven: @chart-violet; 
-@nui-color-classification-twelve: @chart-violet-dark; 
-@nui-color-classification-thirteen: @chart-blue-dark; 
+@nui-color-classification-one: @white;
+@nui-color-classification-two: @swi_gray;
+@nui-color-classification-three: @black;
+@nui-color-classification-four: @ok_green;
+@nui-color-classification-five: @swi_green;
+@nui-color-classification-six: @swi_yellow;
+@nui-color-classification-seven: @swi_orange;
+@nui-color-classification-eight: @chart-orange;
+@nui-color-classification-nine: @critical_red;
+@nui-color-classification-ten: @chart-pink;
+@nui-color-classification-eleven: @chart-violet;
+@nui-color-classification-twelve: @chart-violet-dark;
+@nui-color-classification-thirteen: @chart-blue-dark;
 @nui-color-classification-fourteen: @primary_blue;

--- a/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.html
+++ b/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.html
@@ -41,6 +41,8 @@
                     class="nui-text-widget nui-widget__header__content-title"
                     [title]="title"
                     *ngIf="!url || editMode"
+                    role="heading"
+                    aria-level="2"
                 >
                     {{ title }}
                 </div>
@@ -56,6 +58,8 @@
                         "
                         class="nui-text-widget nui-widget__header__content-title"
                         [nuiTooltip]="linkTooltip"
+                        role="heading"
+                        aria-level="2"
                         >{{ title }}</a
                     >
                 </div>

--- a/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.html
+++ b/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.html
@@ -37,18 +37,20 @@
                 "
             >
                 <!-- text only header with no url defined -->
-                <div
+                <h2
                     class="nui-text-widget nui-widget__header__content-title"
                     [title]="title"
                     *ngIf="!url || editMode"
-                    role="heading"
-                    aria-level="2"
                 >
                     {{ title }}
-                </div>
+                </h2>
 
                 <!-- link version of the header -->
-                <div *ngIf="url && !editMode">
+                <h2
+                    *ngIf="url && !editMode"
+                    class="nui-text-widget nui-widget__header__content-title"
+                    [title]="title"
+                >
                     <a
                         [href]="url"
                         (click)="prepareLink($event)"
@@ -56,13 +58,10 @@
                         (mousedown)="
                             $event.stopPropagation(); $event.preventDefault()
                         "
-                        class="nui-text-widget nui-widget__header__content-title"
                         [nuiTooltip]="linkTooltip"
-                        role="heading"
-                        aria-level="2"
                         >{{ title }}</a
                     >
-                </div>
+                </h2>
 
                 <div
                     *ngIf="subtitle"

--- a/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.less
+++ b/packages/dashboards/src/lib/components/widget/widget-header/widget-header.component.less
@@ -57,7 +57,12 @@
             &-title {
                 display: block;
                 max-width: 100%;
+                margin: 0;
                 .text-overflow(ellipsis);
+
+                a {
+                    color: inherit;
+                }
 
                 &-container {
                     flex: 1;

--- a/packages/dashboards/src/lib/configurator/components/wizard/dashwiz-step/dashwiz-step.component.html
+++ b/packages/dashboards/src/lib/configurator/components/wizard/dashwiz-step/dashwiz-step.component.html
@@ -8,6 +8,7 @@
         cdkScrollable
         class="h-100 overflow-auto configurator-scrollable"
         tabindex="0"
+        [attr.aria-label]="title || null"
     >
         <ng-container *ngTemplateOutlet="stepTemplate"></ng-container>
     </div>

--- a/packages/dashboards/src/lib/configurator/components/wizard/dashwiz-step/dashwiz-step.component.html
+++ b/packages/dashboards/src/lib/configurator/components/wizard/dashwiz-step/dashwiz-step.component.html
@@ -7,6 +7,7 @@
     <div
         cdkScrollable
         class="h-100 overflow-auto configurator-scrollable"
+        tabindex="0"
     >
         <ng-container *ngTemplateOutlet="stepTemplate"></ng-container>
     </div>


### PR DESCRIPTION
## Frontend Pull Request Description
Fixed AxeDevTool accessibility requirements on home summary page issues.

<!-- Provide a brief summary of the changes made in the frontend project. -->
Jiras:
https://swicloud.atlassian.net/browse/OO-50765
https://swicloud.atlassian.net/browse/OO-50699
https://swicloud.atlassian.net/browse/OO-50862
https://swicloud.atlassian.net/browse/OO-50565
https://swicloud.atlassian.net/browse/OO-50701
https://swicloud.atlassian.net/browse/OO-50786
https://swicloud.atlassian.net/browse/OO-59252
https://swicloud.atlassian.net/browse/OO-50766

Set-2:
https://swicloud.atlassian.net/browse/OO-50705
https://swicloud.atlassian.net/browse/OO-50767
https://swicloud.atlassian.net/browse/OO-50768
https://swicloud.atlassian.net/browse/NUI-6264

Before:
<img width="1916" height="816" alt="image" src="https://github.com/user-attachments/assets/ff7be637-03eb-4c39-a118-f578705196a0" />

After fix:
<img width="1919" height="839" alt="image" src="https://github.com/user-attachments/assets/5324779a-8b05-4267-9099-11b88d1bc638" />

**Banner contrast:**
<img width="1006" height="341" alt="image" src="https://github.com/user-attachments/assets/17d8632f-27e7-479c-8d41-92c9db9eec1f" />

**Action button contrast**
<img width="494" height="343" alt="image" src="https://github.com/user-attachments/assets/4ac245ac-c327-434d-82e9-c7c2099d9761" />


Set-2:
<img width="1919" height="817" alt="image" src="https://github.com/user-attachments/assets/28459c6f-1ef0-4411-9499-95736060adb5" />

<img width="1919" height="792" alt="image" src="https://github.com/user-attachments/assets/dd769ce2-7cb1-435c-b751-91f93cdd4a26" />

<img width="1919" height="735" alt="image" src="https://github.com/user-attachments/assets/cef00ac7-c437-4217-a5d8-19dd4078f2cf" />

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
