### PR TITLE
Upgrade to angular 21 small issues

### DIFF
--- a/packages/bits/src/lib/button/button.component.ts
+++ b/packages/bits/src/lib/button/button.component.ts
@@ -240,10 +240,9 @@ should be set explicitly: `,
     }
 
     private setIsContentEmptyValue() {
-        const projectedText =
-            this.contentContainer?.element.nativeElement.textContent.trim();
-
-        this._isContentEmpty = !projectedText;
+        const innerHTML =
+            this.contentContainer?.element.nativeElement.innerHTML;
+        this._isContentEmpty = !innerHTML || !innerHTML.trim();
     }
 
     private setupRepeatEvent() {

--- a/packages/bits/src/lib/selector/selector.component.ts
+++ b/packages/bits/src/lib/selector/selector.component.ts
@@ -179,7 +179,7 @@ export class SelectorComponent
 
         const selection = this.checkboxChecked
             ? SelectionType.All
-            : SelectionType.UnselectAll;
+            : SelectionType.None;
         this.status = selection;
         this.selectionHasChanged = true;
 

--- a/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
+++ b/packages/bits/src/lib/table/table-virtual-scroll/table-sticky-header.directive.ts
@@ -320,27 +320,31 @@ export class TableStickyHeaderDirective implements AfterViewInit, OnDestroy {
 
         // Note: When cdkVirtualFor is present, use its dataStream.
         // When it is absent (e.g. after Angular CDK v21 migration where cdkVirtualFor was
-        // removed from the table row template), fall back to the viewport's renderedRangeStream which
-        // fires whenever the visible item range changes (data loads, sorting, filtering, etc.).
-        const dataSource = this.virtualFor?.dataStream ?? this.viewport.renderedRangeStream;
-        // const resolvedDataStream: Observable<unknown> =
-        //     rawDataSource != null && typeof (rawDataSource as any).pipe === "function"
-        //         ? (rawDataSource as Observable<unknown>)
-        //         : this.viewport.renderedRangeStream;
-
+        // removed from the table row template), fall back to a MutationObserver on the table
+        // body to detect row additions/removals. This is more reliable than renderedRangeStream
+        // which does not fire when the CDK table renders rows without cdkVirtualFor.
+        const dataSource: Observable<unknown> =
+            this.virtualFor?.dataStream ??
+            merge(
+                this.viewport.renderedRangeStream,
+                // MutationObserver fires whenever rows are added or removed from tbody
+                new Observable<void>((observer) => {
+                    if (!this.bodyRef) {
+                        return;
+                    }
+                    const mo = new MutationObserver(() => observer.next());
+                    mo.observe(this.bodyRef, { childList: true });
+                    return () => mo.disconnect();
+                })
+            );
 
         const dataStream$ = dataSource.pipe(
-          // give CDK some time to render rows after a change
-          delay(0, asyncScheduler),
-          tap(() => this.updateNativeHeaderPlaceholder())
+            // give CDK some time to render rows after a change
+            delay(0, asyncScheduler),
+            tap(() => this.updateNativeHeaderPlaceholder())
         );
 
-        merge(
-            onScroll$,
-            onResize$,
-            tableColumnsUpdate$,
-            dataStream$
-        )
+        merge(onScroll$, onResize$, tableColumnsUpdate$, dataStream$)
             .pipe(
                 // Note: Preventing function to be invoked multiple times
                 // by merging new observable only if the previous one was completed

--- a/packages/dashboards/src/lib/configurator/services/configurator.service.spec.ts
+++ b/packages/dashboards/src/lib/configurator/services/configurator.service.spec.ts
@@ -33,11 +33,12 @@ import {
     fakeAsync,
     flush,
     TestBed,
+    tick,
 } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { Gridster, GridsterItem } from "angular-gridster2";
-import { of } from "rxjs";
+import { CompactType, Gridster, GridsterItem } from "angular-gridster2";
+import { of, Subject } from "rxjs";
 
 import { NuiPanelModule } from "@nova-ui/bits";
 
@@ -45,6 +46,7 @@ import { ConfiguratorService } from "./configurator.service";
 import { IConfigurator } from "./types";
 import { PreviewOverlayComponent } from "../../common/components/preview-overlay/preview-overlay.component";
 import { DashboardComponent } from "../../components/dashboard/dashboard.component";
+import { DEFAULT_GRIDSTER_CONFIG } from "../../components/dashboard/default-gridster-config";
 import { WidgetComponent } from "../../components/widget/widget.component";
 import { GridsterItemWidgetIdDirective } from "../../directives/gridster-item-widget-id/gridster-item-widget-id.directive";
 import { mockLoggerService } from "../../mocks.spec";
@@ -99,18 +101,72 @@ class MockRendererFactory {
     }
 }
 
+const getOriginalWidget = () => ({
+    id: "id",
+    type: "proportional",
+    pizzagna: {
+        structure: {
+            structureComponent: {
+                id: "structureComponent",
+                componentType: "StructureComponentType",
+            },
+        },
+        configuration: {
+            configurationComponent: {
+                id: "configurationComponent",
+                componentType: "ConfigurationComponentType",
+            },
+        },
+        data: {
+            dataComponent: {
+                id: "dataComponent",
+                componentType: "DataComponentType",
+            },
+        },
+    },
+    version: 1,
+});
+
+const getUpdatedWidget = () => ({
+    id: "id",
+    type: "table",
+    pizzagna: {
+        structure: {
+            structureComponent: {
+                id: "structureComponent2",
+                componentType: "StructureComponentType2",
+            },
+        },
+        configuration: {
+            configurationComponent: {
+                id: "configurationComponent2",
+                componentType: "ConfigurationComponentType2",
+            },
+        },
+        data: {
+            dataComponent: {
+                id: "dataComponent2",
+                componentType: "DataComponentType2",
+            },
+        },
+    },
+    version: 2,
+});
+
 describe("ConfiguratorService > ", () => {
     let service: ConfiguratorService;
     let dashboardComponent: DashboardComponent;
-    let configuratorNativeElement: any;
+    let dashboardFixture: ComponentFixture<DashboardComponent>;
     let configuratorArgs: IConfigurator;
     let widgetTypesService: WidgetTypesService;
-    let configComponentFixture: ComponentFixture<ConfiguratorComponent>;
+    let configuratorHostElement: HTMLElement;
+    let configuratorComponentRef: ComponentRef<ConfiguratorComponent>;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-                Gridster, GridsterItem,
+                Gridster,
+                GridsterItem,
                 PortalModule,
                 NuiPanelModule,
                 RouterTestingModule.withRoutes([]),
@@ -126,14 +182,30 @@ describe("ConfiguratorService > ", () => {
             ],
             providers: [WidgetTypesService],
         });
-        dashboardComponent =
-            TestBed.createComponent(DashboardComponent).componentInstance;
-        configComponentFixture = TestBed.createComponent(ConfiguratorComponent);
-        configuratorNativeElement =
-            configComponentFixture.debugElement.nativeElement;
+        dashboardFixture = TestBed.createComponent(DashboardComponent);
+        dashboardComponent = dashboardFixture.componentInstance;
+        dashboardComponent.dashboard = { widgets: {}, positions: {} };
+        dashboardComponent.gridsterConfig = { ...DEFAULT_GRIDSTER_CONFIG };
+        dashboardFixture.detectChanges();
         const appRef = TestBed.inject(ApplicationRef) as ApplicationRef;
         const router = TestBed.inject(Router);
         appRef.attachView = (): void => {};
+
+        configuratorHostElement = document.createElement("div");
+        configuratorComponentRef = {
+            instance: {
+                changeDetector: {
+                    detectChanges: () => {},
+                },
+                result: new Subject<any>(),
+                formPortalAttached: new Subject<any>(),
+                handleSubmitError: () => {},
+            } as ConfiguratorComponent,
+            hostView: {
+                rootNodes: [configuratorHostElement],
+            } as any,
+            destroy: () => {},
+        } as ComponentRef<ConfiguratorComponent>;
 
         widgetTypesService = TestBed.inject(WidgetTypesService);
         widgetTypesService.registerWidgetType("table", 2, table);
@@ -141,7 +213,7 @@ describe("ConfiguratorService > ", () => {
 
         service = new ConfiguratorService(
             new MockComponentFactoryResolver(
-                configComponentFixture.componentRef
+                configuratorComponentRef
             ) as ComponentFactoryResolver,
             widgetTypesService,
             new MockInjector(),
@@ -160,11 +232,10 @@ describe("ConfiguratorService > ", () => {
     });
 
     afterEach(() => {
-        configComponentFixture.destroy();
-    });
-
-    afterEach(() => {
-        document.body.removeChild(configuratorNativeElement);
+        dashboardFixture.destroy();
+        if (document.body.contains(configuratorHostElement)) {
+            document.body.removeChild(configuratorHostElement);
+        }
     });
 
     describe("open > ", () => {
@@ -180,57 +251,8 @@ describe("ConfiguratorService > ", () => {
 
     describe("handleSubmit >", () => {
         it("should update widget on dashboard", fakeAsync(() => {
-            const originalWidget = {
-                id: "id",
-                type: "proportional",
-                pizzagna: {
-                    structure: {
-                        structureComponent: {
-                            id: "structureComponent",
-                            componentType: "StructureComponentType",
-                        },
-                    },
-                    configuration: {
-                        configurationComponent: {
-                            id: "configurationComponent",
-                            componentType: "ConfigurationComponentType",
-                        },
-                    },
-                    data: {
-                        dataComponent: {
-                            id: "dataComponent",
-                            componentType: "DataComponentType",
-                        },
-                    },
-                },
-                version: 1,
-            };
-
-            const newWidget = {
-                id: "id",
-                type: "table",
-                pizzagna: {
-                    structure: {
-                        structureComponent: {
-                            id: "structureComponent2",
-                            componentType: "StructureComponentType2",
-                        },
-                    },
-                    configuration: {
-                        configurationComponent: {
-                            id: "configurationComponent2",
-                            componentType: "ConfigurationComponentType2",
-                        },
-                    },
-                    data: {
-                        dataComponent: {
-                            id: "dataComponent2",
-                            componentType: "DataComponentType2",
-                        },
-                    },
-                },
-                version: 2,
-            };
+            const originalWidget = getOriginalWidget();
+            const newWidget = getUpdatedWidget();
 
             dashboardComponent.dashboard = {
                 positions: {
@@ -245,6 +267,7 @@ describe("ConfiguratorService > ", () => {
                     [originalWidget.id]: originalWidget,
                 },
             };
+            dashboardComponent.gridsterConfig = { ...DEFAULT_GRIDSTER_CONFIG };
 
             // we don't want anything to happen here
             service.close = () => {};
@@ -269,32 +292,157 @@ describe("ConfiguratorService > ", () => {
 
             flush();
 
-            configComponentFixture.whenStable().then(() => {
-                expect(removeWidgetSpy).toHaveBeenCalledWith("id", false);
+            expect(removeWidgetSpy).toHaveBeenCalledWith("id", false);
 
-                const dashboardWidget =
-                    dashboardComponent.dashboard.widgets["id"];
+            const dashboardWidget = dashboardComponent.dashboard.widgets["id"];
 
-                expect(dashboardWidget.type).toBe(newWidget.type);
-                expect(dashboardWidget.version).toBe(newWidget.version);
+            expect(dashboardWidget.type).toBe(newWidget.type);
+            expect(dashboardWidget.version).toBe(newWidget.version);
 
-                expect(dashboardWidget.pizzagna.data).toBeUndefined(
-                    "data to be erased"
-                );
+            expect(dashboardWidget.pizzagna.data).toBeUndefined(
+                "data to be erased"
+            );
 
-                expect(dashboardWidget.pizzagna.configuration).toBe(
-                    newWidget.pizzagna.configuration,
-                    "configuration to be taken from the updated widget"
-                );
+            expect(dashboardWidget.pizzagna.configuration).toBe(
+                newWidget.pizzagna.configuration,
+                "configuration to be taken from the updated widget"
+            );
 
-                expect(dashboardWidget.pizzagna.structure).toBe(
-                    widgetTypesService.getWidgetType(
-                        newWidget.type,
-                        newWidget.version
-                    ).widget.structure,
-                    "structure to be taken from the new widget's type"
-                );
-            });
+            expect(dashboardWidget.pizzagna.structure).toBe(
+                widgetTypesService.getWidgetType(
+                    newWidget.type,
+                    newWidget.version
+                ).widget.structure,
+                "structure to be taken from the new widget's type"
+            );
+        }));
+
+        it("should temporarily disable compacting and then restore the original compactType", fakeAsync(() => {
+            const originalWidget = getOriginalWidget();
+            const newWidget = getUpdatedWidget();
+
+            dashboardComponent.dashboard = {
+                positions: {
+                    [originalWidget.id]: {
+                        x: 0,
+                        y: 0,
+                        rows: 1,
+                        cols: 1,
+                    },
+                },
+                widgets: {
+                    [originalWidget.id]: originalWidget,
+                },
+            };
+            dashboardComponent.gridsterConfig = {
+                ...DEFAULT_GRIDSTER_CONFIG,
+                compactType: CompactType.CompactLeft,
+            };
+
+            service.close = () => {};
+
+            const removeWidgetSpy = spyOn(
+                dashboardComponent,
+                "removeWidget"
+            ).and.callThrough();
+            const updateWidgetSpy = spyOn(
+                dashboardComponent,
+                "updateWidget"
+            ).and.callThrough();
+
+            of(newWidget)
+                .pipe(
+                    service.handleSubmit(
+                        {
+                            widget: originalWidget,
+                            dashboardComponent,
+                        },
+                        // @ts-ignore: Suppressed for test purposes
+                        undefined
+                    )
+                )
+                .subscribe();
+
+            expect(removeWidgetSpy).toHaveBeenCalledWith("id", false);
+            expect(dashboardComponent.gridsterConfig.compactType).toBe(
+                CompactType.None
+            );
+
+            tick(0, { processNewMacroTasksSynchronously: false });
+
+            expect(updateWidgetSpy).toHaveBeenCalledWith(
+                jasmine.objectContaining({
+                    id: newWidget.id,
+                })
+            );
+            expect(dashboardComponent.gridsterConfig.compactType).toBe(
+                CompactType.None
+            );
+
+            tick();
+
+            expect(dashboardComponent.gridsterConfig.compactType).toBe(
+                CompactType.CompactLeft
+            );
+        }));
+
+        it("should preserve other gridsterConfig fields while toggling compactType", fakeAsync(() => {
+            const originalWidget = getOriginalWidget();
+            const newWidget = getUpdatedWidget();
+            const draggable = {
+                enabled: true,
+                ignoreContent: false,
+                dragHandleClass: "drag-handle",
+            };
+
+            dashboardComponent.dashboard = {
+                positions: {
+                    [originalWidget.id]: {
+                        x: 0,
+                        y: 0,
+                        rows: 1,
+                        cols: 1,
+                    },
+                },
+                widgets: {
+                    [originalWidget.id]: originalWidget,
+                },
+            };
+            dashboardComponent.gridsterConfig = {
+                ...DEFAULT_GRIDSTER_CONFIG,
+                compactType: CompactType.CompactUp,
+                margin: 24,
+                draggable,
+            };
+
+            service.close = () => {};
+
+            of(newWidget)
+                .pipe(
+                    service.handleSubmit(
+                        {
+                            widget: originalWidget,
+                            dashboardComponent,
+                        },
+                        // @ts-ignore: Suppressed for test purposes
+                        undefined
+                    )
+                )
+                .subscribe();
+
+            expect(dashboardComponent.gridsterConfig.margin).toBe(24);
+            expect(dashboardComponent.gridsterConfig.draggable).toBe(draggable);
+            expect(dashboardComponent.gridsterConfig.compactType).toBe(
+                CompactType.None
+            );
+
+            flush();
+
+            expect(dashboardComponent.gridsterConfig.margin).toBe(24);
+            expect(dashboardComponent.gridsterConfig.draggable).toBe(draggable);
+            expect(dashboardComponent.gridsterConfig.compactType).toBe(
+                CompactType.CompactUp
+            );
         }));
     });
 });

--- a/packages/dashboards/src/lib/configurator/services/configurator.service.ts
+++ b/packages/dashboards/src/lib/configurator/services/configurator.service.ts
@@ -156,9 +156,6 @@ export class ConfiguratorService {
                         let widgetToSet: IWidget;
                         const dashboardWidget =
                             dashboardComponent.dashboard.widgets[widget.id];
-                        const originalPositions = cloneDeep(
-                            dashboardComponent.dashboard.positions
-                        );
 
                         if (dashboardWidget) {
                             widgetToSet = {

--- a/packages/dashboards/src/lib/configurator/services/configurator.service.ts
+++ b/packages/dashboards/src/lib/configurator/services/configurator.service.ts
@@ -43,6 +43,7 @@ import { IWidget } from "../../components/widget/types";
 import { WidgetUpdateOperation } from "../../configurator/services/types";
 import { WidgetTypesService } from "../../services/widget-types.service";
 import { ConfiguratorComponent } from "../components/configurator/configurator.component";
+import { CompactType } from "angular-gridster2";
 
 @Injectable()
 export class ConfiguratorService {
@@ -155,6 +156,10 @@ export class ConfiguratorService {
                         let widgetToSet: IWidget;
                         const dashboardWidget =
                             dashboardComponent.dashboard.widgets[widget.id];
+                        const originalPositions = cloneDeep(
+                            dashboardComponent.dashboard.positions
+                        );
+
                         if (dashboardWidget) {
                             widgetToSet = {
                                 ...widget,
@@ -171,6 +176,13 @@ export class ConfiguratorService {
                             widgetToSet = widget;
                         }
 
+                        // keeping original CompactType and setting it to None to prevent gridster realign widgets after update
+                        const originalCompactType =
+                            dashboardComponent.gridsterConfig.compactType;
+                        dashboardComponent.gridsterConfig = {
+                            ...dashboardComponent.gridsterConfig,
+                            compactType: CompactType.None,
+                        };
                         // first we remove the widget so that we can recreate it from scratch
                         dashboardComponent.removeWidget(
                             widgetToSet.id,
@@ -180,6 +192,13 @@ export class ConfiguratorService {
                         // then we wait for the removal to take effect and we create the widget again
                         setTimeout(() => {
                             dashboardComponent.updateWidget(widgetToSet);
+                            setTimeout(() => {
+                                // returning original CompactType after update
+                                dashboardComponent.gridsterConfig = {
+                                    ...dashboardComponent.gridsterConfig,
+                                    compactType: originalCompactType,
+                                };
+                            });
                         });
                     }
 


### PR DESCRIPTION
## Frontend Pull Request Description

Fix small issues after upgrade to Angular 21:

- prevent reordering widgets after configurator save
- fix width mismatch with table widget header and rows
- fix small regression issues in selector and button components

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
