### PR TITLE
fix: replace yarn commands with npm in publish script

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -32,8 +32,8 @@ PACKAGE_VERSION=$(node -p "require('./dist/package.json').version")
 PACKAGE_LICENSE=$(node -p "require('./dist/package.json').license")
 
 echo -e "//registry.npmjs.org/:_authToken=$NPM_TOKEN\nalways-auth=true" > .npmrc
-yarn config set init-license $PACKAGE_LICENSE
-yarn config set registry $NPM_CONFIG_REGISTRY
+npm config set init-license $PACKAGE_LICENSE
+npm config set registry $NPM_CONFIG_REGISTRY
 
 npm info $PACKAGE_NAME@$PACKAGE_VERSION version 2>/dev/null && {
     echo "Package $PACKAGE_NAME@$PACKAGE_VERSION does already exist on npmjs.org"
@@ -43,12 +43,12 @@ npm info $PACKAGE_NAME@$PACKAGE_VERSION version 2>/dev/null && {
 case $CIRCLE_BRANCH in
       "release/"*)
           echo "Publishing release package | $PACKAGE_NAME @ $PACKAGE_VERSION"
-            yarn publish ./dist --access public
+            npm publish ./dist --access public
             ;;
 
       "main" | "next" | "hotfix/"* | "cci/"*)
           echo "Publishing $CIRCLE_BRANCH package | $PACKAGE_NAME @ $PACKAGE_VERSION"
-            yarn publish ./dist --tag $CIRCLE_BRANCH --access public
+            npm publish ./dist --tag $CIRCLE_BRANCH --access public
             ;;
       *)
           echo "Feature branch build - publish skipped"


### PR DESCRIPTION
## Frontend Pull Request Description

<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
