### PR TITLE
nui-toolbar access

### DIFF
--- a/packages/bits/src/lib/button/button.component.html
+++ b/packages/bits/src/lib/button/button.component.html
@@ -12,6 +12,7 @@
     [icon]="icon"
     [iconSize]="getIconSize()"
     [iconColor]="iconColor"
+    [decorative]="true"
 ></nui-icon>
 <div #contentContainer class="nui-button__content">
     <ng-content></ng-content>

--- a/packages/bits/src/lib/toolbar/toolbar-keyboard.service.spec.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-keyboard.service.spec.ts
@@ -123,6 +123,36 @@ describe("Services > ", () => {
                 expect(spy).toHaveBeenCalled();
             });
 
+            it("should navigate to first element on pressing Home key", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const last = items[items.length - 1];
+                const spy = spyOn(first, "focus");
+
+                last.focus();
+
+                service.onKeyDown({
+                    ...keyboardEventMock,
+                    code: KEYBOARD_CODE.HOME,
+                } as KeyboardEvent);
+                expect(spy).toHaveBeenCalled();
+            });
+
+            it("should navigate to last element on pressing End key", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const last = items[items.length - 1];
+                const spy = spyOn(last, "focus");
+
+                first.focus();
+
+                service.onKeyDown({
+                    ...keyboardEventMock,
+                    code: KEYBOARD_CODE.END,
+                } as KeyboardEvent);
+                expect(spy).toHaveBeenCalled();
+            });
+
             it("should not hijack keyboard events coming from a search input", () => {
                 const searchInput = document.createElement("input");
                 searchInput.type = "search";

--- a/packages/bits/src/lib/toolbar/toolbar-keyboard.service.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-keyboard.service.ts
@@ -51,6 +51,16 @@ export class ToolbarKeyboardService {
             this.navigateByArrow(code);
         }
 
+        if (code === KEYBOARD_CODE.HOME) {
+            event.preventDefault();
+            this.focusFirst();
+        }
+
+        if (code === KEYBOARD_CODE.END) {
+            event.preventDefault();
+            this.focusLast();
+        }
+
         if (code === KEYBOARD_CODE.TAB) {
             this.closeMenuIfOpened();
         }

--- a/packages/bits/src/lib/toolbar/toolbar.component.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.ts
@@ -65,6 +65,9 @@ import { MenuComponent } from "../menu";
     host: {
         class: "nui-toolbar nui-strip-layout nui-flex-container",
         role: "toolbar",
+        "[attr.aria-label]": "ariaLabel || null",
+        "[attr.aria-labelledby]": "ariaLabelledBy || null",
+        "[attr.aria-orientation]": "ariaOrientation || null",
     },
     styleUrls: ["./toolbar.component.less"],
     encapsulation: ViewEncapsulation.None,
@@ -77,6 +80,12 @@ export class ToolbarComponent implements AfterViewInit, OnDestroy {
 
     @ContentChildren(ToolbarItemComponent, { descendants: true })
     public items: QueryList<ToolbarItemComponent>;
+
+    @Input() public ariaLabel?: string;
+
+    @Input() public ariaLabelledBy?: string;
+
+    @Input() public ariaOrientation?: "horizontal" | "vertical";
 
     @Input()
     /**


### PR DESCRIPTION
##Related Jira
https://swicloud.atlassian.net/browse/OO-50848
## Frontend Pull Request Description
(a11y): add ARIA labels, Home/End navigation, and decorative button icons

- Added `aria-label`/`aria-labelledby`
- Added Home & End keyboard support with tests
- Set button icons as decorative (`[decorative]="true"`)
<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
