### PR TITLE
nui-toolbar access

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `@nova-ui/bits` | A11y fixes for nui-toolbar
 - `@nova-ui/bits` | Added unique IDs to expander landmarks
+- `@nova-ui/bits` | new accessible blue for active menu button text
 
 ## [21.0.2] 📅 2026-07-13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [21.0.3] 📅 2026-08-04
+## [21.0.3] 📅 2026-08-11
 
 ### Fixes
 
+- `@nova-ui/bits` | A11y fixes for nui-toolbar
 - `@nova-ui/bits` | Added unique IDs to expander landmarks
 
 ## [21.0.2] 📅 2026-07-13

--- a/packages/bits/src/lib/button/button.component.html
+++ b/packages/bits/src/lib/button/button.component.html
@@ -9,6 +9,7 @@
     [icon]="icon"
     [iconSize]="getIconSize()"
     [iconColor]="iconColor"
+    [decorative]="true"
 ></nui-icon>
 }
 <div #contentContainer class="nui-button__content">

--- a/packages/bits/src/lib/toolbar/toolbar-item.component.spec.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-item.component.spec.ts
@@ -52,5 +52,9 @@ describe("components >", () => {
                 expect(testComponent.menuHidden).toBeFalsy();
             });
         });
+
+        it("should default disabled to false", () => {
+            expect(testComponent.disabled).toBeFalse();
+        });
     });
 });

--- a/packages/bits/src/lib/toolbar/toolbar-item.component.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-item.component.ts
@@ -48,6 +48,8 @@ export class ToolbarItemComponent implements AfterContentInit {
      */
     @Input() public displayStyle = ToolbarItemDisplayStyle.action;
 
+    @Input() public disabled = false;
+
     public menuHidden: boolean;
 
     @Output() public actionDone = new EventEmitter();

--- a/packages/bits/src/lib/toolbar/toolbar-keyboard.service.spec.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-keyboard.service.spec.ts
@@ -143,6 +143,36 @@ describe("Services > ", () => {
 
                 searchInput.remove();
             });
+
+            it("should navigate to first element on pressing Home key", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const last = items[items.length - 1];
+                const spy = spyOn(first, "focus");
+
+                last.focus();
+
+                service.onKeyDown({
+                    ...keyboardEventMock,
+                    code: KEYBOARD_CODE.HOME,
+                } as KeyboardEvent);
+                expect(spy).toHaveBeenCalled();
+            });
+
+            it("should navigate to last element on pressing End key", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const last = items[items.length - 1];
+                const spy = spyOn(last, "focus");
+
+                first.focus();
+
+                service.onKeyDown({
+                    ...keyboardEventMock,
+                    code: KEYBOARD_CODE.END,
+                } as KeyboardEvent);
+                expect(spy).toHaveBeenCalled();
+            });
         });
     });
 });

--- a/packages/bits/src/lib/toolbar/toolbar-keyboard.service.spec.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-keyboard.service.spec.ts
@@ -173,6 +173,116 @@ describe("Services > ", () => {
                 } as KeyboardEvent);
                 expect(spy).toHaveBeenCalled();
             });
+
+            describe("disabled items", () => {
+                afterEach(() => {
+                    const items = service["toolbarItems"];
+
+                    items.forEach((item) => item.removeAttribute("disabled"));
+                });
+
+                it("should skip a disabled item on pressing right arrow button", () => {
+                    const items = service["toolbarItems"];
+                    const [first, middle, last] = items;
+                    const spy = spyOn(last, "focus");
+
+                    middle.setAttribute("disabled", "true");
+                    first.focus();
+
+                    service.onKeyDown(rightButtonPressEvent);
+                    expect(spy).toHaveBeenCalled();
+                });
+
+                it("should not focus a disabled item on pressing End key", () => {
+                    const items = service["toolbarItems"];
+                    const [first, middle, last] = items;
+                    const spy = spyOn(middle, "focus");
+                    const lastSpy = spyOn(last, "focus");
+
+                    last.setAttribute("disabled", "true");
+                    first.focus();
+
+                    service.onKeyDown({
+                        ...keyboardEventMock,
+                        code: KEYBOARD_CODE.END,
+                    } as KeyboardEvent);
+                    expect(spy).toHaveBeenCalled();
+                    expect(lastSpy).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe("onKeyDown with vertical orientation", () => {
+            const downButtonPressEvent = {
+                ...keyboardEventMock,
+                code: KEYBOARD_CODE.ARROW_DOWN,
+            } as KeyboardEvent;
+            const upButtonPressEvent = {
+                ...keyboardEventMock,
+                code: KEYBOARD_CODE.ARROW_UP,
+            } as KeyboardEvent;
+            const rightButtonPressEvent = {
+                ...keyboardEventMock,
+                code: KEYBOARD_CODE.ARROW_RIGHT,
+            } as KeyboardEvent;
+
+            beforeEach(() => {
+                const buttons = document.querySelectorAll(".testButton");
+
+                service.setToolbarItems(
+                    Array.from(buttons) as HTMLElement[],
+                    undefined,
+                    "vertical"
+                );
+            });
+
+            it("should move to next item on pressing down arrow button", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const next = items[1];
+                const spy = spyOn(next, "focus");
+
+                first.focus();
+
+                service.onKeyDown(downButtonPressEvent);
+                expect(spy).toHaveBeenCalled();
+            });
+
+            it("should move to previous item on pressing up arrow button", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const middle = items[1];
+                const spy = spyOn(first, "focus");
+
+                middle.focus();
+
+                service.onKeyDown(upButtonPressEvent);
+                expect(spy).toHaveBeenCalled();
+            });
+
+            it("should wrap to last item on pressing up arrow button on first item", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const last = items[items.length - 1];
+                const spy = spyOn(last, "focus");
+
+                first.focus();
+
+                service.onKeyDown(upButtonPressEvent);
+                expect(spy).toHaveBeenCalled();
+            });
+
+            it("should not navigate on left/right arrow keys", () => {
+                const items = service["toolbarItems"];
+                const first = items[0];
+                const next = items[1];
+                const spy = spyOn(next, "focus");
+
+                first.focus();
+
+                service.onKeyDown(rightButtonPressEvent);
+                expect(spy).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/packages/bits/src/lib/toolbar/toolbar-keyboard.service.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-keyboard.service.ts
@@ -51,6 +51,16 @@ export class ToolbarKeyboardService {
             this.navigateByArrow(code);
         }
 
+        if (code === KEYBOARD_CODE.HOME) {
+            event.preventDefault();
+            this.focusFirst();
+        }
+
+        if (code === KEYBOARD_CODE.END) {
+            event.preventDefault();
+            this.focusLast();
+        }
+
         if (code === KEYBOARD_CODE.TAB) {
             this.closeMenuIfOpened();
         }

--- a/packages/bits/src/lib/toolbar/toolbar-keyboard.service.ts
+++ b/packages/bits/src/lib/toolbar/toolbar-keyboard.service.ts
@@ -27,10 +27,16 @@ import { MenuComponent } from "../menu";
 export class ToolbarKeyboardService {
     private toolbarItems: HTMLElement[] = [];
     private menu: MenuComponent | undefined;
+    private orientation: "horizontal" | "vertical" = "horizontal";
 
-    public setToolbarItems(items: HTMLElement[], menu?: MenuComponent): void {
+    public setToolbarItems(
+        items: HTMLElement[],
+        menu?: MenuComponent,
+        orientation: "horizontal" | "vertical" = "horizontal"
+    ): void {
         this.toolbarItems = items;
         this.menu = menu;
+        this.orientation = orientation;
     }
 
     public onKeyDown(event: KeyboardEvent): void {
@@ -43,9 +49,16 @@ export class ToolbarKeyboardService {
 
         const { code } = event;
 
-        if (
+        const horizontal =
             code === KEYBOARD_CODE.ARROW_LEFT ||
-            code === KEYBOARD_CODE.ARROW_RIGHT
+            code === KEYBOARD_CODE.ARROW_RIGHT;
+        const vertical =
+            code === KEYBOARD_CODE.ARROW_UP ||
+            code === KEYBOARD_CODE.ARROW_DOWN;
+
+        if (
+            (this.orientation !== "vertical" && horizontal) ||
+            (this.orientation === "vertical" && vertical)
         ) {
             event.preventDefault();
             this.navigateByArrow(code);
@@ -84,36 +97,54 @@ export class ToolbarKeyboardService {
 
     private navigateByArrow(code: KEYBOARD_CODE): void {
         const activeEl = document.activeElement;
-        const activeIndex = this.toolbarItems.indexOf(activeEl as HTMLElement);
-        const first = this.toolbarItems[0];
-        const last = this.toolbarItems[this.toolbarItems.length - 1];
+        const items = this.enabledItems;
+        const activeIndex = items.indexOf(activeEl as HTMLElement);
+        const first = items[0];
+        const last = items[items.length - 1];
 
-        if (code === KEYBOARD_CODE.ARROW_LEFT) {
+        if (
+            code === KEYBOARD_CODE.ARROW_LEFT ||
+            code === KEYBOARD_CODE.ARROW_UP
+        ) {
             activeEl === first ? this.focusLast() : this.focusLeft(activeIndex);
         }
 
-        if (code === KEYBOARD_CODE.ARROW_RIGHT && activeIndex !== -1) {
+        if (
+            (code === KEYBOARD_CODE.ARROW_RIGHT ||
+                code === KEYBOARD_CODE.ARROW_DOWN) &&
+            activeIndex !== -1
+        ) {
             activeEl === last
                 ? this.focusFirst()
                 : this.focusRight(activeIndex);
         }
     }
 
+    // items disabled after the list was built are excluded here rather than at build time
+    private get enabledItems(): HTMLElement[] {
+        return this.toolbarItems.filter(
+            (el) =>
+                !el.hasAttribute("disabled") &&
+                el.getAttribute("aria-disabled") !== "true"
+        );
+    }
+
     private focusFirst(): void {
-        this.toolbarItems[0].focus();
+        this.enabledItems[0]?.focus();
         this.closeMenuIfOpened();
     }
 
     private focusLast(): void {
-        this.toolbarItems[this.toolbarItems.length - 1].focus();
+        const items = this.enabledItems;
+        items[items.length - 1]?.focus();
     }
 
     private focusRight(index: number) {
-        this.toolbarItems[index + 1]?.focus();
+        this.enabledItems[index + 1]?.focus();
     }
 
     private focusLeft(index: number) {
-        this.toolbarItems[index - 1]?.focus();
+        this.enabledItems[index - 1]?.focus();
         this.closeMenuIfOpened();
     }
 

--- a/packages/bits/src/lib/toolbar/toolbar.component.html
+++ b/packages/bits/src/lib/toolbar/toolbar.component.html
@@ -5,15 +5,14 @@
     #toolbarContainer
 >
     <div class="nui-toolbar-content__dynamic">
-        @for (commandGroup of commandGroups; track commandGroup; let i = $index;
-        let last = $last) { @for (commandItem of commandGroup.items; track
-        commandItem; let j = $index) {
-        <!-- (!i && !j) is used for set focusable state to first element first group -->
+        @for (commandGroup of commandGroups; track commandGroup; let last =
+        $last) { @for (commandItem of commandGroup.items; track commandItem) {
+        <!-- tabindex 0 is assigned to the first enabled item so a fully-disabled toolbar stays reachable via Tab -->
         <button
             nui-button
             type="button"
             #toolbarButtons
-            [tabindex]="!i && !j ? 0 : -1"
+            [tabindex]="isFirstFocusableItem(commandItem) ? 0 : -1"
             [disabled]="commandItem.disabled"
             (click)="onClickToolbarBtn($event, commandItem)"
             [displayStyle]="
@@ -30,7 +29,7 @@
         </button>
         } @if (!last || showMenu) {
         <nui-divider isVertical="true" size="extra-small"></nui-divider>
-        } } @if (showMenu) {
+        } } } @if (showMenu) {
         <nui-menu
             displayStyle="action"
             #menuComponent
@@ -43,7 +42,8 @@
                 <nui-menu-action
                     [type]="menuItem.isDestructive ? 'destructive' : 'default'"
                     [icon]="menuItem.icon"
-                    (click)="menuItem.actionDone.emit()"
+                    [disabled]="menuItem.disabled"
+                    (actionDone)="menuItem.actionDone.emit()"
                     >{{ menuItem.title }}
                 </nui-menu-action>
                 }

--- a/packages/bits/src/lib/toolbar/toolbar.component.html
+++ b/packages/bits/src/lib/toolbar/toolbar.component.html
@@ -14,6 +14,7 @@
             type="button"
             #toolbarButtons
             [tabindex]="!i && !j ? 0 : -1"
+            [disabled]="commandItem.disabled"
             (click)="onClickToolbarBtn($event, commandItem)"
             [displayStyle]="
                 commandItem.displayStyle === 'main'

--- a/packages/bits/src/lib/toolbar/toolbar.component.html
+++ b/packages/bits/src/lib/toolbar/toolbar.component.html
@@ -29,7 +29,7 @@
         </button>
         } @if (!last || showMenu) {
         <nui-divider isVertical="true" size="extra-small"></nui-divider>
-        } } } @if (showMenu) {
+        } } @if (showMenu) {
         <nui-menu
             displayStyle="action"
             #menuComponent

--- a/packages/bits/src/lib/toolbar/toolbar.component.spec.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.spec.ts
@@ -210,5 +210,47 @@ describe("components >", () => {
                 expect(spy).toHaveBeenCalledWith(keyboardEventMock);
             });
         });
+
+        describe("aria attributes >", () => {
+            let toolbarEl: HTMLElement;
+
+            beforeEach(() => {
+                toolbarEl =
+                    fixture.debugElement.nativeElement.querySelector(
+                        "nui-toolbar"
+                    );
+            });
+
+            it("should render aria-label when ariaLabel is set", () => {
+                component.ariaLabel = "Main toolbar";
+                fixture.detectChanges();
+                expect(toolbarEl.getAttribute("aria-label")).toBe(
+                    "Main toolbar"
+                );
+            });
+
+            it("should render aria-labelledby when ariaLabelledBy is set", () => {
+                component.ariaLabelledBy = "toolbar-heading";
+                fixture.detectChanges();
+                expect(toolbarEl.getAttribute("aria-labelledby")).toBe(
+                    "toolbar-heading"
+                );
+            });
+
+            it("should render aria-orientation when ariaOrientation is set", () => {
+                component.ariaOrientation = "vertical";
+                fixture.detectChanges();
+                expect(toolbarEl.getAttribute("aria-orientation")).toBe(
+                    "vertical"
+                );
+            });
+
+            it("should not render aria attributes when inputs are not set", () => {
+                fixture.detectChanges();
+                expect(toolbarEl.hasAttribute("aria-label")).toBeFalse();
+                expect(toolbarEl.hasAttribute("aria-labelledby")).toBeFalse();
+                expect(toolbarEl.hasAttribute("aria-orientation")).toBeFalse();
+            });
+        });
     });
 });

--- a/packages/bits/src/lib/toolbar/toolbar.component.spec.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.spec.ts
@@ -30,6 +30,7 @@ import {
     flush,
     TestBed,
 } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import noop from "lodash/noop";
 
 import { IToolbarSelectionState, ToolbarItemType } from "./public-api";
@@ -50,7 +51,12 @@ import { MenuComponent } from "../menu";
     template: `
         <nui-toolbar>
             <nui-toolbar-group title="g1">
-                <nui-toolbar-item type="primary" icon="edit" title="edit">
+                <nui-toolbar-item
+                    type="primary"
+                    icon="edit"
+                    title="edit"
+                    [disabled]="firstItemDisabled"
+                >
                 </nui-toolbar-item>
                 <nui-toolbar-item type="primary" icon="edit" title="edit">
                 </nui-toolbar-item>
@@ -60,7 +66,12 @@ import { MenuComponent } from "../menu";
             <nui-toolbar-group title="g2">
                 <nui-toolbar-item type="primary" icon="add" title="add">
                 </nui-toolbar-item>
-                <nui-toolbar-item type="secondary" icon="add" title="add">
+                <nui-toolbar-item
+                    type="secondary"
+                    icon="add"
+                    title="add"
+                    [disabled]="menuItemDisabled"
+                >
                 </nui-toolbar-item>
                 <nui-toolbar-item type="secondary" icon="add" title="add">
                 </nui-toolbar-item>
@@ -69,7 +80,10 @@ import { MenuComponent } from "../menu";
     `,
     standalone: false,
 })
-class TestWrapperComponent {}
+class TestWrapperComponent {
+    public firstItemDisabled = false;
+    public menuItemDisabled = false;
+}
 
 describe("components >", () => {
     describe("toolbar >", () => {
@@ -250,6 +264,84 @@ describe("components >", () => {
                 expect(toolbarEl.hasAttribute("aria-label")).toBeFalse();
                 expect(toolbarEl.hasAttribute("aria-labelledby")).toBeFalse();
                 expect(toolbarEl.hasAttribute("aria-orientation")).toBeFalse();
+            });
+
+            it("should sync a runtime ariaOrientation change to the keyboard service", () => {
+                const spy = spyOn(
+                    component["keyboardService"],
+                    "setToolbarItems"
+                );
+
+                component.ariaOrientation = "vertical";
+
+                expect(spy).toHaveBeenCalledWith(
+                    jasmine.any(Array),
+                    component.menu,
+                    "vertical"
+                );
+            });
+        });
+
+        describe("isFirstFocusableItem >", () => {
+            it("should return true for the first enabled item when the first item is disabled", () => {
+                const disabledItem = {
+                    disabled: true,
+                } as ToolbarItemComponent;
+                const enabledItem = {
+                    disabled: false,
+                } as ToolbarItemComponent;
+                component.commandGroups = [
+                    { items: [disabledItem, enabledItem] },
+                ];
+
+                expect(
+                    component.isFirstFocusableItem(disabledItem)
+                ).toBeFalse();
+                expect(component.isFirstFocusableItem(enabledItem)).toBeTrue();
+            });
+
+            it("should return false for every item when all items are disabled", () => {
+                const disabledItem = {
+                    disabled: true,
+                } as ToolbarItemComponent;
+                component.commandGroups = [{ items: [disabledItem] }];
+
+                expect(
+                    component.isFirstFocusableItem(disabledItem)
+                ).toBeFalse();
+            });
+        });
+
+        describe("disabled items >", () => {
+            it("should assign tabindex 0 to the first enabled item when the first item is disabled", () => {
+                const wrapper = fixture.componentInstance;
+                wrapper.firstItemDisabled = true;
+                fixture.detectChanges();
+                component.splitToolbarItems();
+                fixture.detectChanges();
+
+                const buttons =
+                    fixture.debugElement.nativeElement.querySelectorAll(
+                        "button[nui-button]"
+                    );
+                expect(buttons[0].getAttribute("tabindex")).toBe("-1");
+                expect(buttons[1].getAttribute("tabindex")).toBe("0");
+            });
+
+            it("should pass the disabled state of a menu item to nui-menu-action in the overflow menu", () => {
+                const wrapper = fixture.componentInstance;
+                wrapper.menuItemDisabled = true;
+                fixture.detectChanges();
+
+                const menuActions = fixture.debugElement.queryAll(
+                    By.css("nui-menu-action")
+                );
+                expect((menuActions[0].nativeElement as any).disabled).toBe(
+                    true
+                );
+                expect((menuActions[1].nativeElement as any).disabled).toBe(
+                    false
+                );
             });
         });
     });

--- a/packages/bits/src/lib/toolbar/toolbar.component.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.ts
@@ -65,6 +65,9 @@ import { MenuComponent } from "../menu";
     host: {
         class: "nui-toolbar nui-strip-layout nui-flex-container",
         role: "toolbar",
+        "[attr.aria-label]": "ariaLabel || null",
+        "[attr.aria-labelledby]": "ariaLabelledBy || null",
+        "[attr.aria-orientation]": "ariaOrientation || null",
     },
     styleUrls: ["./toolbar.component.less"],
     encapsulation: ViewEncapsulation.None,
@@ -79,6 +82,12 @@ export class ToolbarComponent
 
     @ContentChildren(ToolbarItemComponent, { descendants: true })
     public items: QueryList<ToolbarItemComponent>;
+
+    @Input() public ariaLabel?: string;
+
+    @Input() public ariaLabelledBy?: string;
+
+    @Input() public ariaOrientation?: "horizontal" | "vertical";
 
     @Input()
     /**

--- a/packages/bits/src/lib/toolbar/toolbar.component.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.ts
@@ -354,7 +354,8 @@ export class ToolbarComponent
 
                 this.keyboardService.setToolbarItems(
                     this.toolbarItems,
-                    this.menu
+                    this.menu,
+                    this.ariaOrientation
                 );
             });
     }

--- a/packages/bits/src/lib/toolbar/toolbar.component.ts
+++ b/packages/bits/src/lib/toolbar/toolbar.component.ts
@@ -87,7 +87,20 @@ export class ToolbarComponent
 
     @Input() public ariaLabelledBy?: string;
 
-    @Input() public ariaOrientation?: "horizontal" | "vertical";
+    @Input()
+    public set ariaOrientation(value: "horizontal" | "vertical" | undefined) {
+        this._ariaOrientation = value;
+        // keep the keyboard service in sync with runtime orientation changes
+        this.keyboardService.setToolbarItems(
+            this.toolbarItems,
+            this.menu,
+            value
+        );
+    }
+
+    public get ariaOrientation(): "horizontal" | "vertical" | undefined {
+        return this._ariaOrientation;
+    }
 
     @Input()
     /**
@@ -134,6 +147,7 @@ export class ToolbarComponent
     private destructiveItems: any[];
     private destroy$: Subject<void> = new Subject<void>();
     private moveToolbarItemsTimeout?: ReturnType<typeof setTimeout>;
+    private _ariaOrientation?: "horizontal" | "vertical";
 
     constructor(
         public element: ElementRef,
@@ -330,6 +344,16 @@ export class ToolbarComponent
         );
     }
 
+    public isFirstFocusableItem(commandItem: ToolbarItemComponent): boolean {
+        for (const group of this.commandGroups) {
+            const firstEnabled = group.items.find((item) => !item.disabled);
+            if (firstEnabled) {
+                return firstEnabled === commandItem;
+            }
+        }
+        return false;
+    }
+
     private subscribeToToolbarStepsChanges(): void {
         this.toolbarButtons.changes
             .pipe(takeUntil(this.destroy$))
@@ -341,9 +365,13 @@ export class ToolbarComponent
                     .filter((el) => !!el);
 
                 if (this.menu) {
-                    // In case all buttons are hidden within the Commands menu we want this menu to receive the focus
-                    // If at least one button is visible in the toolbar it should receive the focus first upon navigating onto the toolbar
-                    const tabIndex = buttons.length ? "-1" : "0";
+                    // In case all buttons are hidden within the Commands menu, or all visible buttons are disabled,
+                    // we want this menu to receive the focus.
+                    // If at least one enabled button is visible in the toolbar it should receive the focus first upon navigating onto the toolbar
+                    const hasEnabledItem = this.toolbarItems.some(
+                        (el) => !(el as HTMLButtonElement).disabled
+                    );
+                    const tabIndex = hasEnabledItem ? "-1" : "0";
 
                     this.menu.menuToggle.nativeElement.setAttribute(
                         "tabindex",

--- a/packages/bits/src/styles/nui-framework-colors-dark.less
+++ b/packages/bits/src/styles/nui-framework-colors-dark.less
@@ -71,7 +71,7 @@
 @nui-color-text-light: @white;
 @nui-color-text-light-secondary: darken(@white, 20%); // unofficial
 @nui-color-text-highlight-platform_bar: @swi_orange;
-@nui-color-text-highlight-platform_bar-blue: @blue_cyan;
+@nui-color-text-highlight-platform_bar-blue: @blue_cyan--accessible;
 @nui-color-text-critical: @critical_red--dark;
 @nui-color-text-ok: @ok_green;
 @nui-color-text-warning: @black;

--- a/packages/bits/src/styles/nui-framework-colors.less
+++ b/packages/bits/src/styles/nui-framework-colors.less
@@ -80,7 +80,7 @@
 @nui-color-text-inverse-secondary: fade(@white, 60%);
 @nui-color-text-inverse-disabled: fade(@white, 30%);
 @nui-color-text-highlight-platform_bar: @swi_orange;
-@nui-color-text-highlight-platform_bar-blue: @blue_cyan;
+@nui-color-text-highlight-platform_bar-blue: @blue_cyan--accessible;
 @nui-color-text-critical: @critical_red;
 @nui-color-text-ok: @ok_green;
 @nui-color-text-warning: @black;

--- a/packages/bits/src/styles/nui-framework-palette.less
+++ b/packages/bits/src/styles/nui-framework-palette.less
@@ -33,6 +33,7 @@
 @primary-blue--dark: #13bbff;
 @cyan: #00c4d2;
 @blue_cyan: #00a0be;
+@blue_cyan--accessible: #7cd6e6;
 @down_red: #950000;
 @critical_red: #dd2c00;
 @critical_red--dark: #ff3f0f;


### PR DESCRIPTION
(a11y): add ARIA labels, Home/End navigation, and decorative button icons

- Added `aria-label`/`aria-labelledby`
- Added Home & End keyboard support with tests
- Set button icons as decorative (`[decorative]="true"`)

## Frontend Pull Request Description

<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
