### PR TITLE
Bugfix/oo 50779 nui checkbox incorrect markup fix for main

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [21.0.2] 📅 2026-07-13
+
+### Fixes
+
+- `@nova-ui/bits` | A11y fix for nui-checkbox
 
 ## [21.0.1] 📅 2025-05-21
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
     "trigger-pipeline-build-ci": "bash scripts/trigger-pipeline-build",
     "verify-ci": "bash scripts/verify-published"
   },
-  "version": "21.0.1",
+  "version": "21.0.2",
   "workspaces": ["packages/*"]
 }

--- a/packages/bits/e2e/components/checkbox-group/checkbox-group.a11y.spec.ts
+++ b/packages/bits/e2e/components/checkbox-group/checkbox-group.a11y.spec.ts
@@ -24,7 +24,6 @@ import { Helpers, test } from "../../setup";
 test.describe("a11y: checkbox-group", () => {
     // disabling the rule until NUI-6015 is addressed
     const rulesToDisable: string[] = [
-        "aria-allowed-role",
         "aria-toggle-field-name",
         "aria-required-attr",
     ];

--- a/packages/bits/e2e/components/checkbox-group/checkbox-group.e2e.spec.ts
+++ b/packages/bits/e2e/components/checkbox-group/checkbox-group.e2e.spec.ts
@@ -91,7 +91,7 @@ test.describe("USERCONTROL Checkbox Group", () => {
     });
 
     test("should not change the value if clicked on disabled checkbox inside the checkbox group", async () => {
-        await checkboxGroupCheckboxDisabled.toggle();
+        await checkboxGroupCheckboxDisabled.toBeDisabled();
         await checkboxGroupCheckboxDisabled.toBeChecked();
     });
 

--- a/packages/bits/e2e/components/checkbox/checkbox.a11y.spec.ts
+++ b/packages/bits/e2e/components/checkbox/checkbox.a11y.spec.ts
@@ -2,7 +2,7 @@ import { CheckboxAtom } from "./checkbox.atom";
 import { test, Helpers } from "../../setup";
 
 // disabling the rule until NUI-6015 is addressed
-const rulesToDisable: string[] = ["aria-allowed-role", "nested-interactive"];
+const rulesToDisable: string[] = ["nested-interactive"];
 
 test.describe("a11y: checkbox", () => {
     test.beforeEach(async ({ page }) => {

--- a/packages/bits/e2e/components/checkbox/checkbox.e2e.spec.ts
+++ b/packages/bits/e2e/components/checkbox/checkbox.e2e.spec.ts
@@ -65,7 +65,7 @@ test.describe("USERCONTROL Checkbox", () => {
 
         test("should not check on disabled items", async () => {
             await expect(atomDisabled.getInputElement).toBeChecked();
-            await atomDisabled.toggle();
+            await atomDisabled.toBeDisabled();
             await expect(atomDisabled.getInputElement).toBeChecked();
         });
     });

--- a/packages/bits/e2e/components/repeat/repeat.e2e.spec.ts
+++ b/packages/bits/e2e/components/repeat/repeat.e2e.spec.ts
@@ -193,9 +193,8 @@ test.describe("USERCONTROL Repeat", () => {
 
             test("should not allow multi selection of disabled items by clicking on checkbox", async () => {
                 await expectOriginalSelection();
-                await list.selectCheckbox(0);
-                await expectOriginalSelection();
-                await list.selectCheckbox(4);
+                await list.getCheckbox(0).toBeDisabled();
+                await list.getCheckbox(4).toBeDisabled();
                 await expectOriginalSelection();
             });
 

--- a/packages/bits/e2e/components/table/table.atom.ts
+++ b/packages/bits/e2e/components/table/table.atom.ts
@@ -149,11 +149,12 @@ export class TableAtom extends Atom {
                 throw new Error("row is not defined");
             }
             const cell = this.getCell(rowIndex, 0);
-            const selectionControl = cell.locator('input[type="checkbox"]');
+            // Check the visible checkbox component wrapper, not the hidden native input
+            const checkboxComponent = cell.locator(".nui-checkbox").first();
             if (enabled) {
-                await expect(selectionControl.first()).toBeVisible();
+                await expect(checkboxComponent).toBeVisible();
             } else {
-                await expect(selectionControl).toHaveCount(0);
+                await expect(cell.locator(".nui-checkbox")).toHaveCount(0);
             }
 
             selectionValidationPassed++;

--- a/packages/bits/e2e/components/table/table.atom.ts
+++ b/packages/bits/e2e/components/table/table.atom.ts
@@ -149,7 +149,7 @@ export class TableAtom extends Atom {
                 throw new Error("row is not defined");
             }
             const cell = this.getCell(rowIndex, 0);
-            const selectionControl = cell.getByRole("checkbox");
+            const selectionControl = cell.locator('input[type="checkbox"]');
             if (enabled) {
                 await expect(selectionControl.first()).toBeVisible();
             } else {

--- a/packages/bits/package.json
+++ b/packages/bits/package.json
@@ -104,5 +104,5 @@
     "test:dev": "ng test lib -c dev"
   },
   "typings": "public_api.d.ts",
-  "version": "21.0.1"
+  "version": "21.0.2"
 }

--- a/packages/bits/schematics/package.json
+++ b/packages/bits/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nova-schematics",
   "license": "Apache-2.0",
-  "version": "21.0.1",
+  "version": "21.0.2",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/bits/src/lib/checkbox/checkbox.component.html
+++ b/packages/bits/src/lib/checkbox/checkbox.component.html
@@ -2,10 +2,8 @@
     <label
         class="nui-checkbox__label"
         #checkboxLabel
-        role="checkbox"
         [attr.aria-label]="ariaLabel || null"
         [attr.aria-labelledby]="ariaLabelledby"
-        [attr.aria-checked]="getAriaChecked()"
         [attr.aria-describedby]="ariaDescribedby"
         [attr.tabindex]="!disabled ? 0 : -1"
         [title]="title"
@@ -18,6 +16,7 @@
                 #inputViewContainer
                 class="nui-checkbox__input"
                 type="checkbox"
+                [attr.aria-checked]="getAriaChecked()"
                 [attr.name]="name"
                 [value]="value"
                 [checked]="checked"

--- a/packages/bits/src/lib/checkbox/checkbox.component.spec.ts
+++ b/packages/bits/src/lib/checkbox/checkbox.component.spec.ts
@@ -73,6 +73,17 @@ describe("components >", () => {
                 expect(subject.valueChange.emit).toHaveBeenCalled();
             });
 
+            it("should not change value or emit when disabled and clicked", () => {
+                spyOn(subject.valueChange, "emit").and.callThrough();
+                subject.disabled = true;
+                fixture.detectChanges();
+
+                checkboxInput.click();
+
+                expect(subject.checked).toBeFalsy();
+                expect(subject.valueChange.emit).not.toHaveBeenCalled();
+            });
+
             it("should output not emit events if focused, or hovered", () => {
                 spyOn(subject.valueChange, "emit").and.callThrough();
 

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -6,7 +6,7 @@
     }
   ],
   "dependencies": {
-    "@nova-ui/bits": "~21.0.1"
+    "@nova-ui/bits": "~21.0.2"
   },
   "devDependencies": {
     "@types/d3": "^5.7.2",
@@ -89,5 +89,5 @@
     "test": "ng test lib -c coverage",
     "test:dev": "ng test lib -c dev"
   },
-  "version": "21.0.1"
+  "version": "21.0.2"
 }

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -6,8 +6,8 @@
     }
   ],
   "dependencies": {
-    "@nova-ui/bits": "~21.0.1",
-    "@nova-ui/charts": "~21.0.1"
+    "@nova-ui/bits": "~21.0.2",
+    "@nova-ui/charts": "~21.0.2"
   },
   "devDependencies": {
     "@apollo/client": "4.1.7",
@@ -91,5 +91,5 @@
     "test": "ng t lib -c coverage",
     "test:dev": "ng t lib -c dev"
   },
-  "version": "21.0.1"
+  "version": "21.0.2"
 }

--- a/packages/dashboards/schematics/package.json
+++ b/packages/dashboards/schematics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboards-schematics",
   "license": "Apache-2.0",
-  "version": "21.0.1",
+  "version": "21.0.2",
   "scripts": {
     "assemble": "run-s build copy:json copy:data test copy:dist",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Frontend Pull Request Description
A11y fix for nui-checkbox:
Move the aria-checked attribute off the label and onto the native checkbox input to improve ARIA semantics (removed role="checkbox" and aria-checked from the label; added [attr.aria-checked] on the input). Update E2E accessibility specs by removing "aria-allowed-role" from the disabled rules arrays.
<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
