### PR TITLE
Add keyboard navigation to date picker

### DIFF
--- a/packages/bits/e2e/components/datepicker/datepicker.atom.ts
+++ b/packages/bits/e2e/components/datepicker/datepicker.atom.ts
@@ -127,6 +127,10 @@ export class DatepickerAtom extends Atom {
         await el.click();
     };
 
+    public toggleToBeDisabled = async (): Promise<void> => {
+        await expect(this.getLocatorByCss(".nui-datepicker__icon")).toBeDisabled();
+    };
+
     public clickChangeModeButton = async (): Promise<void> =>
         this.getLocatorByCss(".change-mode-button").click();
 

--- a/packages/bits/e2e/components/datepicker/datepicker.atom.ts
+++ b/packages/bits/e2e/components/datepicker/datepicker.atom.ts
@@ -101,8 +101,12 @@ export class DatepickerAtom extends Atom {
         const currentTitle = await this.getTitleText.textContent();
         if (currentTitle && currentTitle.length === 4) {
             const currentYear: number = Math.floor(parseInt(currentTitle, 10));
-            const rangeStart: number = currentYear;
-            const rangeEnd: number = currentYear + 19;
+            // The year grid shows a fixed block of `yearRange` (default 20) years,
+            // aligned the same way as the picker's getStartingYear calculation.
+            const yearRange = 20;
+            const rangeStart: number =
+                Math.floor((currentYear - 1) / yearRange) * yearRange + 1;
+            const rangeEnd: number = rangeStart + yearRange - 1;
             newTitle = `${rangeStart} - ${rangeEnd}`;
         } else if (currentTitle) {
             newTitle = currentTitle.substring(currentTitle.length - 4);

--- a/packages/bits/e2e/components/datetimepicker/date-time-picker.visual.spec.ts
+++ b/packages/bits/e2e/components/datetimepicker/date-time-picker.visual.spec.ts
@@ -65,6 +65,9 @@ test.describe(`Visual tests: ${name}`, () => {
         await dateTimePickerRanged.datePicker.toggle();
         await camera.say.cheese(`Ranged picker disables dates out of range`);
 
+        // Dismiss the open date-picker overlays before opening the dialog so their
+        // calendar (and its "Today" button) can't intercept the dialog button click.
+        await Helpers.clickOnEmptySpace();
         await dialogButton.click();
         dateTimePickerDialog = Atom.find<DateTimepickerAtom>(
             DateTimepickerAtom,

--- a/packages/bits/e2e/components/datetimepicker/date-time-picker.visual.spec.ts
+++ b/packages/bits/e2e/components/datetimepicker/date-time-picker.visual.spec.ts
@@ -65,9 +65,6 @@ test.describe(`Visual tests: ${name}`, () => {
         await dateTimePickerRanged.datePicker.toggle();
         await camera.say.cheese(`Ranged picker disables dates out of range`);
 
-        // Dismiss the open date-picker overlays before opening the dialog so their
-        // calendar (and its "Today" button) can't intercept the dialog button click.
-        await Helpers.clickOnEmptySpace();
         await dialogButton.click();
         dateTimePickerDialog = Atom.find<DateTimepickerAtom>(
             DateTimepickerAtom,

--- a/packages/bits/e2e/components/form-field/form-field.e2e.spec.ts
+++ b/packages/bits/e2e/components/form-field/form-field.e2e.spec.ts
@@ -198,8 +198,7 @@ test.describe("USERCONTROL form-field >", () => {
         await textbox.toBeDisabled();
         await textboxNumber.toBeDisabled();
         await datepicker.toBeDisabled();
-        await datepicker.toggle();
-        await datepicker.getOverlay.toNotBeOpened();
+        await datepicker.toggleToBeDisabled();
         await radioGroup.toHaveDisabledItemsCount(1);
         await checkbox.toBeDisabled();
         await checkboxGroup.toBeDisabled();
@@ -290,8 +289,7 @@ test.describe("USERCONTROL form-field >", () => {
             await textbox.toBeDisabled();
             await textboxNumber.toBeDisabled();
             await datepicker.toBeDisabled();
-            await datepicker.toggle();
-            await datepicker.getOverlay.toNotBeOpened();
+            await datepicker.toggleToBeDisabled();
             await radioGroup.toHaveDisabledItemsCount(1);
             await select.toBeDisabled();
             await switchElement.isDisabled();

--- a/packages/bits/src/lib/date-picker/date-picker-day-picker.component.html
+++ b/packages/bits/src/lib/date-picker/date-picker-day-picker.component.html
@@ -2,7 +2,6 @@
     *ngIf="datePicker.datepickerMode === 'day'"
     role="grid"
     [attr.aria-labelledby]="datePicker.uniqueId + '-title'"
-    aria-activedescendant="activeDateId"
 >
     <thead>
         <tr>
@@ -13,7 +12,6 @@
                     displayStyle="action"
                     icon="caret-left"
                     (click)="datePicker.move(-1, $event)"
-                    tabindex="-1"
                 ></button>
             </th>
             <th [attr.colspan]="5 + (datePicker.showWeeks ? 1 : 0)">
@@ -31,7 +29,6 @@
                             datePicker.datepickerMode === datePicker.maxMode
                     }"
                     (click)="datePicker.toggleMode($event)"
-                    tabindex="-1"
                 >
                     <span>{{ title }}</span>
                 </button>
@@ -43,7 +40,6 @@
                     displayStyle="action"
                     icon="caret-right"
                     (click)="datePicker.move(1, $event)"
-                    tabindex="-1"
                 ></button>
             </th>
         </tr>
@@ -74,6 +70,7 @@
                 >
                     <button
                         *ngIf="cell.isCellVisible"
+                        #dayCellButton
                         nui-button
                         type="button"
                         displayStyle="action"
@@ -82,8 +79,8 @@
                             disabled: cell.disabled
                         }"
                         [disabled]="cell.disabled"
+                        [attr.tabindex]="cell.current ? 0 : -1"
                         (click)="datePicker.select(cell.date, $event)"
-                        tabindex="-1"
                     >
                         <span
                             [ngClass]="{

--- a/packages/bits/src/lib/date-picker/date-picker-day-picker.component.spec.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-day-picker.component.spec.ts
@@ -93,5 +93,72 @@ describe("components >", () => {
             ).toBe(true);
             expect(dates.length).toBe(10);
         });
+
+        describe("focusActiveCell >", () => {
+            it("should move DOM focus to the button representing the active (current) day cell", () => {
+                const otherButton = { focus: jasmine.createSpy("focus") };
+                const activeButton = { focus: jasmine.createSpy("focus") };
+                dayPicker.rows = [
+                    {
+                        isRowVisible: true,
+                        days: [
+                            { isCellVisible: true, current: false },
+                            { isCellVisible: true, current: true },
+                        ],
+                    },
+                ];
+                (dayPicker as any).dayCellButtons = {
+                    toArray: () => [
+                        { nativeElement: otherButton },
+                        { nativeElement: activeButton },
+                    ],
+                };
+
+                dayPicker.focusActiveCell();
+
+                expect(activeButton.focus).toHaveBeenCalled();
+                expect(otherButton.focus).not.toHaveBeenCalled();
+            });
+
+            it("should skip cells that are hidden (not visible in the current view)", () => {
+                const renderedButton = { focus: jasmine.createSpy("focus") };
+                dayPicker.rows = [
+                    {
+                        isRowVisible: true,
+                        days: [
+                            { isCellVisible: false, current: true },
+                            { isCellVisible: true, current: false },
+                        ],
+                    },
+                    {
+                        isRowVisible: false,
+                        days: [{ isCellVisible: true, current: true }],
+                    },
+                ];
+                (dayPicker as any).dayCellButtons = {
+                    toArray: () => [{ nativeElement: renderedButton }],
+                };
+
+                dayPicker.focusActiveCell();
+
+                expect(renderedButton.focus).not.toHaveBeenCalled();
+            });
+
+            it("should do nothing when there is no active day cell", () => {
+                dayPicker.rows = [
+                    {
+                        isRowVisible: true,
+                        days: [{ isCellVisible: true, current: false }],
+                    },
+                ];
+                (dayPicker as any).dayCellButtons = {
+                    toArray: () => [
+                        { nativeElement: { focus: jasmine.createSpy() } },
+                    ],
+                };
+
+                expect(() => dayPicker.focusActiveCell()).not.toThrow();
+            });
+        });
     });
 });

--- a/packages/bits/src/lib/date-picker/date-picker-day-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-day-picker.component.ts
@@ -159,9 +159,8 @@ export class DayPickerComponent implements OnInit {
     }
 
     /**
-     * Moves DOM focus to the day cell button that represents the currently
-     * navigated/active date (i.e. the cell whose `current` flag is set),
-     * enabling roving-tabindex keyboard navigation across the grid.
+     * Focuses the day cell button for the currently active date (the cell
+     * whose `current` flag is set), for roving-tabindex keyboard navigation.
      */
     public focusActiveCell(): void {
         const visibleCells = this.rows

--- a/packages/bits/src/lib/date-picker/date-picker-day-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-day-picker.component.ts
@@ -18,7 +18,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component, OnInit, ViewEncapsulation } from "@angular/core";
+import {
+    Component,
+    ElementRef,
+    OnInit,
+    QueryList,
+    ViewChildren,
+    ViewEncapsulation,
+} from "@angular/core";
 import moment, { Moment } from "moment/moment";
 
 import { DatePickerInnerComponent } from "./date-picker-inner.component";
@@ -31,6 +38,9 @@ import { DatePickerInnerComponent } from "./date-picker-inner.component";
     standalone: false,
 })
 export class DayPickerComponent implements OnInit {
+    @ViewChildren("dayCellButton", { read: ElementRef })
+    private dayCellButtons: QueryList<ElementRef<HTMLButtonElement>>;
+
     public labels: any[] = [];
     public title: string;
     public rows: any[] = [];
@@ -146,6 +156,22 @@ export class DayPickerComponent implements OnInit {
             },
             "day"
         );
+    }
+
+    /**
+     * Moves DOM focus to the day cell button that represents the currently
+     * navigated/active date (i.e. the cell whose `current` flag is set),
+     * enabling roving-tabindex keyboard navigation across the grid.
+     */
+    public focusActiveCell(): void {
+        const visibleCells = this.rows
+            .filter((row) => row.isRowVisible)
+            .flatMap((row) => row.days.filter((cell: any) => cell.isCellVisible));
+        const activeIndex = visibleCells.findIndex((cell: any) => cell.current);
+        const buttons = this.dayCellButtons?.toArray() ?? [];
+        const activeButton = buttons[activeIndex];
+
+        activeButton?.nativeElement.focus();
     }
 
     protected getDates(startDate: Moment, n: number): Moment[] {

--- a/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
@@ -86,6 +86,10 @@ export class DatePickerInnerComponent
 
     public calendarMoved: Subject<Moment> = new Subject<Moment>();
 
+    // Emits the new mode whenever the view switches between day/month/year, so the
+    // host can keep keyboard focus inside the newly rendered grid.
+    public modeChanged: Subject<string> = new Subject<string>();
+
     protected _value: Moment | undefined;
     protected _todayDate: Moment = moment();
 
@@ -272,6 +276,7 @@ export class DatePickerInnerComponent
         } else {
             this.datepickerMode =
                 this.modes[this.modes.indexOf(this.datepickerMode) - 1];
+            this.modeChanged.next(this.datepickerMode);
             event.stopPropagation();
         }
 
@@ -326,6 +331,7 @@ export class DatePickerInnerComponent
 
         this.datepickerMode =
             this.modes[this.modes.indexOf(this.datepickerMode) + direction];
+        this.modeChanged.next(this.datepickerMode);
         this.refreshView();
         event.stopPropagation();
     }
@@ -385,5 +391,6 @@ export class DatePickerInnerComponent
 
     public ngOnDestroy(): void {
         this.calendarMoved.complete();
+        this.modeChanged.complete();
     }
 }

--- a/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-inner.component.ts
@@ -86,8 +86,7 @@ export class DatePickerInnerComponent
 
     public calendarMoved: Subject<Moment> = new Subject<Moment>();
 
-    // Emits the new mode whenever the view switches between day/month/year, so the
-    // host can keep keyboard focus inside the newly rendered grid.
+    // Emits the new mode on day/month/year switches so the host can refocus the grid.
     public modeChanged: Subject<string> = new Subject<string>();
 
     protected _value: Moment | undefined;

--- a/packages/bits/src/lib/date-picker/date-picker-keyboard.service.spec.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-keyboard.service.spec.ts
@@ -1,0 +1,598 @@
+// © 2022 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { fakeAsync, tick } from "@angular/core/testing";
+import moment from "moment/moment";
+
+import { DatePickerKeyboardService } from "./date-picker-keyboard.service";
+import { KEYBOARD_CODE } from "../../constants/keycode.constants";
+
+const keyBoardEventFactory = (
+    code: KEYBOARD_CODE,
+    target?: Partial<HTMLElement>
+): KeyboardEvent =>
+    ({
+        preventDefault: () => {},
+        code,
+        target,
+    }) as KeyboardEvent;
+
+describe("Services >", () => {
+    describe("DatePickerKeyboardService", () => {
+        const service = new DatePickerKeyboardService();
+        let datePickerInnerMock: any;
+        let dayPickerMock: any;
+        let monthPickerMock: any;
+        let yearPickerMock: any;
+        let overlayMock: any;
+        let toggleButtonMock: any;
+
+        beforeEach(() => {
+            datePickerInnerMock = {
+                value: moment("2022-06-15"),
+                datepickerMode: "day",
+                yearRange: 20,
+                refreshView: () => {},
+                calendarMoved: { next: () => {} },
+                isDisabled: () => false,
+            };
+            dayPickerMock = { focusActiveCell: () => {} };
+            monthPickerMock = { focusActiveCell: () => {} };
+            yearPickerMock = { focusActiveCell: () => {} };
+            overlayMock = { showing: false, show: () => {}, hide: () => {} };
+            toggleButtonMock = { focus: () => {} };
+
+            service.initService(
+                datePickerInnerMock,
+                dayPickerMock,
+                overlayMock,
+                toggleButtonMock,
+                monthPickerMock,
+                yearPickerMock
+            );
+        });
+
+        describe("onKeyDown", () => {
+            it("should call 'handleClosedCalendar' when the overlay is not showing", () => {
+                const spy = spyOn(service as any, "handleClosedCalendar");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_DOWN);
+
+                service.onKeyDown(event);
+                expect(spy).toHaveBeenCalledWith(event);
+            });
+
+            it("should call 'handleOpenedCalendar' when the overlay is showing", () => {
+                overlayMock.showing = true;
+                const spy = spyOn(service as any, "handleOpenedCalendar");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_DOWN);
+
+                service.onKeyDown(event);
+                expect(spy).toHaveBeenCalledWith(event);
+            });
+
+            it("should treat the calendar as always open when there is no overlay (inline mode)", () => {
+                service.initService(datePickerInnerMock, dayPickerMock);
+                const spy = spyOn(service as any, "handleOpenedCalendar");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service.onKeyDown(event);
+                expect(spy).toHaveBeenCalledWith(event);
+            });
+        });
+
+        describe("handleClosedCalendar", () => {
+            it("should show the overlay and call preventDefault on ArrowDown", () => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_DOWN);
+                const preventDefaultSpy = spyOn(event, "preventDefault");
+                const showSpy = spyOn(overlayMock, "show");
+
+                service["handleClosedCalendar"](event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                expect(showSpy).toHaveBeenCalled();
+            });
+
+            it("should do nothing for other keys", () => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+                const showSpy = spyOn(overlayMock, "show");
+
+                service["handleClosedCalendar"](event);
+
+                expect(showSpy).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("handleOpenedCalendar", () => {
+            beforeEach(() => {
+                overlayMock.showing = true;
+            });
+
+            it("should hide the overlay and restore focus to the toggle button on Escape", () => {
+                const hideSpy = spyOn(overlayMock, "hide");
+                const focusSpy = spyOn(toggleButtonMock, "focus");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ESCAPE);
+
+                service["handleOpenedCalendar"](event);
+
+                expect(hideSpy).toHaveBeenCalled();
+                expect(focusSpy).toHaveBeenCalled();
+            });
+
+            it("should not attempt to hide when there is no overlay (inline mode)", () => {
+                service.initService(datePickerInnerMock, dayPickerMock);
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ESCAPE);
+
+                expect(() =>
+                    service["handleOpenedCalendar"](event)
+                ).not.toThrow();
+            });
+
+            it("should ignore navigation keys for an unrecognized mode", () => {
+                datePickerInnerMock.datepickerMode = "decade";
+                const refreshSpy = spyOn(datePickerInnerMock, "refreshView");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service["handleOpenedCalendar"](event);
+
+                expect(refreshSpy).not.toHaveBeenCalled();
+            });
+
+            it("should not navigate the grid when an arrow key comes from the text input", fakeAsync(() => {
+                const startValue = datePickerInnerMock.value.clone();
+                const refreshSpy = spyOn(datePickerInnerMock, "refreshView");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT, {
+                    tagName: "INPUT",
+                });
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(refreshSpy).not.toHaveBeenCalled();
+                expect(
+                    datePickerInnerMock.value.isSame(startValue, "day")
+                ).toBeTruthy();
+            }));
+
+            it("should still close on Escape when the event comes from the text input", () => {
+                const hideSpy = spyOn(overlayMock, "hide");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ESCAPE, {
+                    tagName: "INPUT",
+                });
+
+                service["handleOpenedCalendar"](event);
+
+                expect(hideSpy).toHaveBeenCalled();
+            });
+
+            it("should move to the first day of the month on Home", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.HOME);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-06-01"), "day")
+                ).toBeTruthy();
+            }));
+
+            it("should move to the last day of the month on End", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.END);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-06-30"), "day")
+                ).toBeTruthy();
+            }));
+
+            it("should move one day forward on ArrowRight", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-06-16"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should move one day back on ArrowLeft", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_LEFT);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-06-14"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should move one week forward on ArrowDown", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_DOWN);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-06-22"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should move one week back on ArrowUp", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_UP);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-06-08"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should move to the next month on PageDown, preserving the day", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.PAGE_DOWN);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-07-15"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should move to the previous month on PageUp, preserving the day", fakeAsync(() => {
+                const event = keyBoardEventFactory(KEYBOARD_CODE.PAGE_UP);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-05-15"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should clamp to the last valid day of the month when paging into a shorter month", fakeAsync(() => {
+                datePickerInnerMock.value = moment("2022-01-31");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.PAGE_DOWN);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-02-28"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should skip disabled dates when moving by day", fakeAsync(() => {
+                datePickerInnerMock.isDisabled = (date: moment.Moment) =>
+                    date.isSame(moment("2022-06-16"), "day");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(
+                        moment("2022-06-17"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should refresh the view and focus the active cell after navigating", fakeAsync(() => {
+                const refreshSpy = spyOn(datePickerInnerMock, "refreshView");
+                const focusSpy = spyOn(dayPickerMock, "focusActiveCell");
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(refreshSpy).toHaveBeenCalled();
+                expect(focusSpy).toHaveBeenCalled();
+            }));
+
+            it("should notify calendarMoved only when the displayed month changes", fakeAsync(() => {
+                const calendarMovedSpy = spyOn(
+                    datePickerInnerMock.calendarMoved,
+                    "next"
+                );
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(calendarMovedSpy).not.toHaveBeenCalled();
+            }));
+
+            it("should notify calendarMoved when navigation crosses into a new month", fakeAsync(() => {
+                datePickerInnerMock.value = moment("2022-06-30");
+                const calendarMovedSpy = spyOn(
+                    datePickerInnerMock.calendarMoved,
+                    "next"
+                );
+                const event = keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT);
+
+                service["handleOpenedCalendar"](event);
+                tick();
+
+                expect(calendarMovedSpy).toHaveBeenCalled();
+            }));
+        });
+
+        describe("month mode navigation", () => {
+            beforeEach(() => {
+                overlayMock.showing = true;
+                datePickerInnerMock.datepickerMode = "month";
+            });
+
+            it("should move one month forward on ArrowRight", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-07-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move one month back on ArrowLeft", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_LEFT)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-05-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move one row (3 months) forward on ArrowDown", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_DOWN)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-09-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move one row (3 months) back on ArrowUp", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_UP)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-03-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move one year forward on PageDown", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.PAGE_DOWN)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2023-06-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move one year back on PageUp", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.PAGE_UP)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2021-06-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move to January on Home", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.HOME)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-01-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should move to December on End", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.END)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2022-12-15"), "month")
+                ).toBeTruthy();
+            }));
+
+            it("should focus the active cell of the month grid after navigating", fakeAsync(() => {
+                const focusSpy = spyOn(monthPickerMock, "focusActiveCell");
+
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT)
+                );
+                tick();
+
+                expect(focusSpy).toHaveBeenCalled();
+            }));
+
+            it("should notify calendarMoved only when the displayed year changes", fakeAsync(() => {
+                const calendarMovedSpy = spyOn(
+                    datePickerInnerMock.calendarMoved,
+                    "next"
+                );
+
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT)
+                );
+                tick();
+
+                expect(calendarMovedSpy).not.toHaveBeenCalled();
+            }));
+
+            it("should notify calendarMoved when navigation crosses into a new year", fakeAsync(() => {
+                datePickerInnerMock.value = moment("2022-12-15");
+                const calendarMovedSpy = spyOn(
+                    datePickerInnerMock.calendarMoved,
+                    "next"
+                );
+
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT)
+                );
+                tick();
+
+                expect(calendarMovedSpy).toHaveBeenCalled();
+            }));
+        });
+
+        describe("year mode navigation", () => {
+            beforeEach(() => {
+                overlayMock.showing = true;
+                datePickerInnerMock.datepickerMode = "year";
+            });
+
+            it("should move one year forward on ArrowRight", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2023-06-15"), "year")
+                ).toBeTruthy();
+            }));
+
+            it("should move one year back on ArrowLeft", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_LEFT)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2021-06-15"), "year")
+                ).toBeTruthy();
+            }));
+
+            it("should move one row (5 years) forward on ArrowDown", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_DOWN)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2027-06-15"), "year")
+                ).toBeTruthy();
+            }));
+
+            it("should move one row (5 years) back on ArrowUp", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_UP)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2017-06-15"), "year")
+                ).toBeTruthy();
+            }));
+
+            it("should page by yearRange (20 years) forward on PageDown", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.PAGE_DOWN)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2042-06-15"), "year")
+                ).toBeTruthy();
+            }));
+
+            it("should page by yearRange (20 years) back on PageUp", fakeAsync(() => {
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.PAGE_UP)
+                );
+                tick();
+
+                expect(
+                    datePickerInnerMock.value.isSame(moment("2002-06-15"), "year")
+                ).toBeTruthy();
+            }));
+
+            it("should focus the active cell of the year grid after navigating", fakeAsync(() => {
+                const focusSpy = spyOn(yearPickerMock, "focusActiveCell");
+
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.ARROW_RIGHT)
+                );
+                tick();
+
+                expect(focusSpy).toHaveBeenCalled();
+            }));
+
+            it("should not respond to Home/End in the year view", fakeAsync(() => {
+                const startValue = datePickerInnerMock.value.clone();
+                const refreshSpy = spyOn(datePickerInnerMock, "refreshView");
+
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.HOME)
+                );
+                service["handleOpenedCalendar"](
+                    keyBoardEventFactory(KEYBOARD_CODE.END)
+                );
+                tick();
+
+                expect(refreshSpy).not.toHaveBeenCalled();
+                expect(
+                    datePickerInnerMock.value.isSame(startValue, "year")
+                ).toBeTruthy();
+            }));
+        });
+    });
+});

--- a/packages/bits/src/lib/date-picker/date-picker-keyboard.service.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-keyboard.service.ts
@@ -28,29 +28,27 @@ import { YearPickerComponent } from "./date-picker-year-picker.component";
 import { KEYBOARD_CODE } from "../../constants/keycode.constants";
 import { OverlayComponent } from "../overlay/overlay-component/overlay.component";
 
-// Safety limit to avoid infinite loops when every remaining date happens to be disabled
+// Safety limit to avoid infinite loops if every remaining date is disabled
 const MAX_DISABLED_DATE_SKIPS = 366;
 
-// Calendar units the grid can navigate by, one per picker mode
+// Calendar units the grid navigates by, one per picker mode
 type CalendarUnit = "days" | "months" | "years";
 
-// Any picker grid the keyboard service can move DOM focus within
+// A picker grid whose active cell can receive DOM focus
 interface FocusablePicker {
     focusActiveCell(): void;
 }
 
 /**
- * Handles keyboard interaction for the `nui-date-picker` day, month and year grids,
- * in line with the WAI-ARIA APG Date Picker Dialog pattern:
- * https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
+ * Keyboard interaction for the day/month/year grids, per the WAI-ARIA APG
+ * Date Picker Dialog pattern.
  * @ignore
  */
 @Injectable()
 export class DatePickerKeyboardService {
-    // Per-mode grid navigation config: the calendar unit each arrow step moves by,
-    // the number of grid columns (used for vertical Up/Down movement), and the unit
-    // PageUp/PageDown jumps by. `pageAmount` is resolved at runtime for the year view,
-    // which spans a full `yearRange`.
+    // Per-mode nav config: arrow step unit, grid columns (for Up/Down), and
+    // the PageUp/PageDown unit. `pageAmount` is omitted for year view, which
+    // resolves it to `yearRange` at runtime.
     private static readonly modeNav: Record<
         string,
         {
@@ -118,8 +116,8 @@ export class DatePickerKeyboardService {
         }
     }
 
-    // True when the key event originates from an editable text field (e.g. the
-    // date input), so grid navigation should defer to native caret behavior.
+    // True when the event comes from an editable field (e.g. the date input),
+    // so grid navigation should defer to native caret behavior.
     private static isFromEditableInput(event: KeyboardEvent): boolean {
         const tagName = (event.target as HTMLElement | null)?.tagName;
 
@@ -150,7 +148,7 @@ export class DatePickerKeyboardService {
     }
 
     public onKeyDown(event: KeyboardEvent): void {
-        // Inline date-pickers have no overlay to open/close - the grid is always considered "open"
+        // Inline pickers have no overlay - the grid is always considered "open"
         const isOpen = !this.overlay || this.overlay.showing;
 
         isOpen ? this.handleOpenedCalendar(event) : this.handleClosedCalendar(event);
@@ -173,8 +171,7 @@ export class DatePickerKeyboardService {
             return;
         }
 
-        // Let the text input keep its native caret movement - don't hijack the
-        // arrow/page keys when the event originates from an editable field.
+        // Don't hijack arrow/page keys from an editable field - keep native caret movement
         if (DatePickerKeyboardService.isFromEditableInput(event)) {
             return;
         }
@@ -207,8 +204,8 @@ export class DatePickerKeyboardService {
             return;
         }
 
-        // Home/End jump to the first/last cell of the current page (day and month
-        // views only; the year view has no natural single edge to jump to).
+        // Home/End jump to first/last cell of the page (day and month only;
+        // year has no single edge to jump to).
         const edge = DatePickerKeyboardService.getEdgeDirection(code);
         if (edge !== undefined) {
             const current = this.getActiveDate();
@@ -229,12 +226,12 @@ export class DatePickerKeyboardService {
         this.toggleButton?.focus();
     }
 
-    // Arrow-key movement: steps by a single grid unit and skips over disabled cells
+    // Steps by one grid unit, skipping disabled cells
     private moveByStep(amount: number, unit: CalendarUnit): void {
         const current = this.getActiveDate();
         const next = current.clone().add(amount, unit);
 
-        // Skip over any disabled cells in the direction of travel
+        // Skip disabled cells in the travel direction
         let attempts = 0;
         while (
             this.datePickerInner.isDisabled(next) &&
@@ -247,8 +244,8 @@ export class DatePickerKeyboardService {
         this.applyActiveDate(current, next);
     }
 
-    // PageUp/PageDown movement: jumps a whole page. moment clamps the day-of-month
-    // automatically when the target month/year is shorter (e.g. Jan 31 -> Feb 28).
+    // Jumps a whole page; moment auto-clamps day-of-month for shorter months
+    // (e.g. Jan 31 -> Feb 28).
     private moveByPage(amount: number, unit: CalendarUnit): void {
         const current = this.getActiveDate();
         const next = current.clone().add(amount, unit);
@@ -270,8 +267,7 @@ export class DatePickerKeyboardService {
         this.focusActiveCell();
     }
 
-    // Identifies the page currently shown by the active grid so that calendarMoved
-    // only fires when navigation shifts the grid to a different page.
+    // Page identifier for the active grid; calendarMoved fires only on page change
     private getPageId(date: Moment): string {
         switch (this.datePickerInner.datepickerMode) {
             case "month":
@@ -290,9 +286,8 @@ export class DatePickerKeyboardService {
         }
     }
 
-    // The first/last cell date of the current page for Home/End (day -> first/last
-    // day of the month, month -> January/December). Returns undefined for modes
-    // without a supported edge (year).
+    // First/last cell of the page for Home/End (day -> 1st/last day of month,
+    // month -> Jan/Dec). Undefined for modes with no supported edge (year).
     private getEdgeDate(
         date: Moment,
         edge: "start" | "end"
@@ -309,7 +304,7 @@ export class DatePickerKeyboardService {
         }
     }
 
-    // The date the grid is currently focused on, defaulting to today when unset
+    // Currently focused date, defaulting to today when unset
     private getActiveDate(): Moment {
         return this.datePickerInner.value
             ? this.datePickerInner.value.clone()
@@ -317,11 +312,11 @@ export class DatePickerKeyboardService {
     }
 
     public focusActiveCell(): void {
-        // Wait a tick so the grid has re-rendered before moving DOM focus.
+        // Wait a tick for the grid to re-render before focusing
         setTimeout(() => this.getActivePicker()?.focusActiveCell());
     }
 
-    // The picker grid matching the current mode, whose cell should receive focus
+    // Picker grid matching the current mode
     private getActivePicker(): FocusablePicker | undefined {
         switch (this.datePickerInner.datepickerMode) {
             case "month":

--- a/packages/bits/src/lib/date-picker/date-picker-keyboard.service.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-keyboard.service.ts
@@ -1,0 +1,336 @@
+// © 2022 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import { Injectable } from "@angular/core";
+import moment, { Moment } from "moment/moment";
+
+import { DayPickerComponent } from "./date-picker-day-picker.component";
+import { DatePickerInnerComponent } from "./date-picker-inner.component";
+import { MonthPickerComponent } from "./date-picker-month-picker.component";
+import { YearPickerComponent } from "./date-picker-year-picker.component";
+import { KEYBOARD_CODE } from "../../constants/keycode.constants";
+import { OverlayComponent } from "../overlay/overlay-component/overlay.component";
+
+// Safety limit to avoid infinite loops when every remaining date happens to be disabled
+const MAX_DISABLED_DATE_SKIPS = 366;
+
+// Calendar units the grid can navigate by, one per picker mode
+type CalendarUnit = "days" | "months" | "years";
+
+// Any picker grid the keyboard service can move DOM focus within
+interface FocusablePicker {
+    focusActiveCell(): void;
+}
+
+/**
+ * Handles keyboard interaction for the `nui-date-picker` day, month and year grids,
+ * in line with the WAI-ARIA APG Date Picker Dialog pattern:
+ * https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
+ * @ignore
+ */
+@Injectable()
+export class DatePickerKeyboardService {
+    private datePickerInner!: DatePickerInnerComponent;
+    private dayPicker!: DayPickerComponent;
+    private monthPicker?: MonthPickerComponent;
+    private yearPicker?: YearPickerComponent;
+    private overlay?: OverlayComponent;
+    private toggleButton?: HTMLElement;
+
+    // Per-mode grid navigation config: the calendar unit each arrow step moves by,
+    // the number of grid columns (used for vertical Up/Down movement), and the unit
+    // PageUp/PageDown jumps by. `pageAmount` is resolved at runtime for the year view,
+    // which spans a full `yearRange`.
+    private static readonly modeNav: Record<
+        string,
+        {
+            stepUnit: CalendarUnit;
+            columns: number;
+            pageUnit: CalendarUnit;
+            pageAmount?: number;
+        }
+    > = {
+        day: {
+            stepUnit: "days",
+            columns: 7,
+            pageUnit: "months",
+            pageAmount: 1,
+        },
+        month: {
+            stepUnit: "months",
+            columns: 3,
+            pageUnit: "years",
+            pageAmount: 1,
+        },
+        year: { stepUnit: "years", columns: 5, pageUnit: "years" },
+    };
+
+    public initService(
+        datePickerInner: DatePickerInnerComponent,
+        dayPicker: DayPickerComponent,
+        overlay?: OverlayComponent,
+        toggleButton?: HTMLElement,
+        monthPicker?: MonthPickerComponent,
+        yearPicker?: YearPickerComponent
+    ): void {
+        this.datePickerInner = datePickerInner;
+        this.dayPicker = dayPicker;
+        this.overlay = overlay;
+        this.toggleButton = toggleButton;
+        this.monthPicker = monthPicker;
+        this.yearPicker = yearPicker;
+    }
+
+    public onKeyDown(event: KeyboardEvent): void {
+        // Inline date-pickers have no overlay to open/close - the grid is always considered "open"
+        const isOpen = !this.overlay || this.overlay.showing;
+
+        isOpen ? this.handleOpenedCalendar(event) : this.handleClosedCalendar(event);
+    }
+
+    private handleClosedCalendar(event: KeyboardEvent): void {
+        if (event.code === KEYBOARD_CODE.ARROW_DOWN) {
+            event.preventDefault();
+            this.overlay?.show();
+            this.focusActiveCell();
+        }
+    }
+
+    private handleOpenedCalendar(event: KeyboardEvent): void {
+        const { code } = event;
+
+        if (code === KEYBOARD_CODE.ESCAPE) {
+            this.closeAndRestoreFocus();
+
+            return;
+        }
+
+        // Let the text input keep its native caret movement - don't hijack the
+        // arrow/page keys when the event originates from an editable field.
+        if (DatePickerKeyboardService.isFromEditableInput(event)) {
+            return;
+        }
+
+        const config =
+            DatePickerKeyboardService.modeNav[
+                this.datePickerInner.datepickerMode
+            ];
+        if (!config) {
+            return;
+        }
+
+        const arrowOffset = DatePickerKeyboardService.getArrowOffset(
+            code,
+            config.columns
+        );
+        if (arrowOffset !== undefined) {
+            event.preventDefault();
+            this.moveByStep(arrowOffset, config.stepUnit);
+
+            return;
+        }
+
+        const pageDirection = DatePickerKeyboardService.getPageDirection(code);
+        if (pageDirection !== undefined) {
+            event.preventDefault();
+            const amount = config.pageAmount ?? this.datePickerInner.yearRange;
+            this.moveByPage(pageDirection * amount, config.pageUnit);
+
+            return;
+        }
+
+        // Home/End jump to the first/last cell of the current page (day and month
+        // views only; the year view has no natural single edge to jump to).
+        const edge = DatePickerKeyboardService.getEdgeDirection(code);
+        if (edge !== undefined) {
+            const current = this.getActiveDate();
+            const next = this.getEdgeDate(current, edge);
+            if (next) {
+                event.preventDefault();
+                this.applyActiveDate(current, next);
+            }
+        }
+    }
+
+    // Arrow keys: horizontal = +/-1 unit, vertical = +/-one grid row (columns)
+    private static getArrowOffset(
+        code: string,
+        columns: number
+    ): number | undefined {
+        switch (code) {
+            case KEYBOARD_CODE.ARROW_RIGHT:
+                return 1;
+            case KEYBOARD_CODE.ARROW_LEFT:
+                return -1;
+            case KEYBOARD_CODE.ARROW_DOWN:
+                return columns;
+            case KEYBOARD_CODE.ARROW_UP:
+                return -columns;
+            default:
+                return undefined;
+        }
+    }
+
+    private static getPageDirection(code: string): number | undefined {
+        switch (code) {
+            case KEYBOARD_CODE.PAGE_DOWN:
+                return 1;
+            case KEYBOARD_CODE.PAGE_UP:
+                return -1;
+            default:
+                return undefined;
+        }
+    }
+
+    private static getEdgeDirection(
+        code: string
+    ): "start" | "end" | undefined {
+        switch (code) {
+            case KEYBOARD_CODE.HOME:
+                return "start";
+            case KEYBOARD_CODE.END:
+                return "end";
+            default:
+                return undefined;
+        }
+    }
+
+    // True when the key event originates from an editable text field (e.g. the
+    // date input), so grid navigation should defer to native caret behavior.
+    private static isFromEditableInput(event: KeyboardEvent): boolean {
+        const tagName = (event.target as HTMLElement | null)?.tagName;
+
+        return tagName === "INPUT" || tagName === "TEXTAREA";
+    }
+
+    private closeAndRestoreFocus(): void {
+        if (!this.overlay) {
+            return;
+        }
+
+        this.overlay.hide();
+        this.toggleButton?.focus();
+    }
+
+    // Arrow-key movement: steps by a single grid unit and skips over disabled cells
+    private moveByStep(amount: number, unit: CalendarUnit): void {
+        const current = this.getActiveDate();
+        const next = current.clone().add(amount, unit);
+
+        // Skip over any disabled cells in the direction of travel
+        let attempts = 0;
+        while (
+            this.datePickerInner.isDisabled(next) &&
+            attempts < MAX_DISABLED_DATE_SKIPS
+        ) {
+            next.add(amount, unit);
+            attempts++;
+        }
+
+        this.applyActiveDate(current, next);
+    }
+
+    // PageUp/PageDown movement: jumps a whole page. moment clamps the day-of-month
+    // automatically when the target month/year is shorter (e.g. Jan 31 -> Feb 28).
+    private moveByPage(amount: number, unit: CalendarUnit): void {
+        const current = this.getActiveDate();
+        const next = current.clone().add(amount, unit);
+
+        this.applyActiveDate(current, next);
+    }
+
+    private applyActiveDate(current: Moment, next: Moment): void {
+        const picker = this.datePickerInner;
+        const pageChanged = this.getPageId(current) !== this.getPageId(next);
+
+        picker.value = next;
+        picker.refreshView();
+
+        if (pageChanged) {
+            picker.calendarMoved.next(next);
+        }
+
+        this.focusActiveCell();
+    }
+
+    // Identifies the page currently shown by the active grid so that calendarMoved
+    // only fires when navigation shifts the grid to a different page.
+    private getPageId(date: Moment): string {
+        switch (this.datePickerInner.datepickerMode) {
+            case "month":
+                return `${date.year()}`;
+            case "year": {
+                // The year grid shows a fixed block of `yearRange` years
+                const range = this.datePickerInner.yearRange;
+                const blockStart =
+                    Math.floor((date.year() - 1) / range) * range + 1;
+
+                return `${blockStart}`;
+            }
+            case "day":
+            default:
+                return `${date.year()}-${date.month()}`;
+        }
+    }
+
+    // The first/last cell date of the current page for Home/End (day -> first/last
+    // day of the month, month -> January/December). Returns undefined for modes
+    // without a supported edge (year).
+    private getEdgeDate(
+        date: Moment,
+        edge: "start" | "end"
+    ): Moment | undefined {
+        const isStart = edge === "start";
+
+        switch (this.datePickerInner.datepickerMode) {
+            case "day":
+                return date.clone().date(isStart ? 1 : date.daysInMonth());
+            case "month":
+                return date.clone().month(isStart ? 0 : 11);
+            default:
+                return undefined;
+        }
+    }
+
+    // The date the grid is currently focused on, defaulting to today when unset
+    private getActiveDate(): Moment {
+        return this.datePickerInner.value
+            ? this.datePickerInner.value.clone()
+            : moment();
+    }
+
+    public focusActiveCell(): void {
+        // Wait a tick so the grid has re-rendered before moving DOM focus.
+        setTimeout(() => this.getActivePicker()?.focusActiveCell());
+    }
+
+    // The picker grid matching the current mode, whose cell should receive focus
+    private getActivePicker(): FocusablePicker | undefined {
+        switch (this.datePickerInner.datepickerMode) {
+            case "month":
+                return this.monthPicker;
+            case "year":
+                return this.yearPicker;
+            case "day":
+            default:
+                return this.dayPicker;
+        }
+    }
+}

--- a/packages/bits/src/lib/date-picker/date-picker-keyboard.service.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-keyboard.service.ts
@@ -47,13 +47,6 @@ interface FocusablePicker {
  */
 @Injectable()
 export class DatePickerKeyboardService {
-    private datePickerInner!: DatePickerInnerComponent;
-    private dayPicker!: DayPickerComponent;
-    private monthPicker?: MonthPickerComponent;
-    private yearPicker?: YearPickerComponent;
-    private overlay?: OverlayComponent;
-    private toggleButton?: HTMLElement;
-
     // Per-mode grid navigation config: the calendar unit each arrow step moves by,
     // the number of grid columns (used for vertical Up/Down movement), and the unit
     // PageUp/PageDown jumps by. `pageAmount` is resolved at runtime for the year view,
@@ -81,6 +74,64 @@ export class DatePickerKeyboardService {
         },
         year: { stepUnit: "years", columns: 5, pageUnit: "years" },
     };
+
+    // Arrow keys: horizontal = +/-1 unit, vertical = +/-one grid row (columns)
+    private static getArrowOffset(
+        code: string,
+        columns: number
+    ): number | undefined {
+        switch (code) {
+            case KEYBOARD_CODE.ARROW_RIGHT:
+                return 1;
+            case KEYBOARD_CODE.ARROW_LEFT:
+                return -1;
+            case KEYBOARD_CODE.ARROW_DOWN:
+                return columns;
+            case KEYBOARD_CODE.ARROW_UP:
+                return -columns;
+            default:
+                return undefined;
+        }
+    }
+
+    private static getPageDirection(code: string): number | undefined {
+        switch (code) {
+            case KEYBOARD_CODE.PAGE_DOWN:
+                return 1;
+            case KEYBOARD_CODE.PAGE_UP:
+                return -1;
+            default:
+                return undefined;
+        }
+    }
+
+    private static getEdgeDirection(
+        code: string
+    ): "start" | "end" | undefined {
+        switch (code) {
+            case KEYBOARD_CODE.HOME:
+                return "start";
+            case KEYBOARD_CODE.END:
+                return "end";
+            default:
+                return undefined;
+        }
+    }
+
+    // True when the key event originates from an editable text field (e.g. the
+    // date input), so grid navigation should defer to native caret behavior.
+    private static isFromEditableInput(event: KeyboardEvent): boolean {
+        const tagName = (event.target as HTMLElement | null)?.tagName;
+
+        return tagName === "INPUT" || tagName === "TEXTAREA";
+    }
+
+    private datePickerInner!: DatePickerInnerComponent;
+    private dayPicker!: DayPickerComponent;
+    private monthPicker?: MonthPickerComponent;
+    private yearPicker?: YearPickerComponent;
+    private overlay?: OverlayComponent;
+    private toggleButton?: HTMLElement;
 
     public initService(
         datePickerInner: DatePickerInnerComponent,
@@ -167,57 +218,6 @@ export class DatePickerKeyboardService {
                 this.applyActiveDate(current, next);
             }
         }
-    }
-
-    // Arrow keys: horizontal = +/-1 unit, vertical = +/-one grid row (columns)
-    private static getArrowOffset(
-        code: string,
-        columns: number
-    ): number | undefined {
-        switch (code) {
-            case KEYBOARD_CODE.ARROW_RIGHT:
-                return 1;
-            case KEYBOARD_CODE.ARROW_LEFT:
-                return -1;
-            case KEYBOARD_CODE.ARROW_DOWN:
-                return columns;
-            case KEYBOARD_CODE.ARROW_UP:
-                return -columns;
-            default:
-                return undefined;
-        }
-    }
-
-    private static getPageDirection(code: string): number | undefined {
-        switch (code) {
-            case KEYBOARD_CODE.PAGE_DOWN:
-                return 1;
-            case KEYBOARD_CODE.PAGE_UP:
-                return -1;
-            default:
-                return undefined;
-        }
-    }
-
-    private static getEdgeDirection(
-        code: string
-    ): "start" | "end" | undefined {
-        switch (code) {
-            case KEYBOARD_CODE.HOME:
-                return "start";
-            case KEYBOARD_CODE.END:
-                return "end";
-            default:
-                return undefined;
-        }
-    }
-
-    // True when the key event originates from an editable text field (e.g. the
-    // date input), so grid navigation should defer to native caret behavior.
-    private static isFromEditableInput(event: KeyboardEvent): boolean {
-        const tagName = (event.target as HTMLElement | null)?.tagName;
-
-        return tagName === "INPUT" || tagName === "TEXTAREA";
     }
 
     private closeAndRestoreFocus(): void {

--- a/packages/bits/src/lib/date-picker/date-picker-month-picker.component.html
+++ b/packages/bits/src/lib/date-picker/date-picker-month-picker.component.html
@@ -8,7 +8,6 @@
                     displayStyle="action"
                     icon="caret-left"
                     (click)="datePicker.move(-1, $event)"
-                    tabindex="-1"
                 ></button>
             </th>
             <th>
@@ -23,7 +22,6 @@
                         disabled: datePicker.datepickerMode === maxMode
                     }"
                     (click)="datePicker.toggleMode($event)"
-                    tabindex="-1"
                 >
                     <span>{{ title }}</span>
                 </button>
@@ -35,7 +33,6 @@
                     displayStyle="action"
                     icon="caret-right"
                     (click)="datePicker.move(1, $event)"
-                    tabindex="-1"
                 ></button>
             </th>
         </tr>
@@ -50,14 +47,15 @@
                 <button
                     nui-button
                     type="button"
+                    #cellButton
                     displayStyle="action"
                     [ngClass]="{
                         selected: cell.selected,
                         disabled: cell.disabled
                     }"
                     [disabled]="cell.disabled"
+                    [attr.tabindex]="cell.current ? 0 : -1"
                     (click)="datePicker.select(cell.date, $event)"
-                    tabindex="-1"
                 >
                     <span [ngClass]="{ 'text-info': cell.current }">{{
                         cell.label

--- a/packages/bits/src/lib/date-picker/date-picker-month-picker.component.spec.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-month-picker.component.spec.ts
@@ -51,5 +51,42 @@ describe("components >", () => {
             expect(inner.setRefreshViewHandler).toHaveBeenCalled();
             expect(inner.setCompareHandler).toHaveBeenCalled();
         });
+
+        describe("focusActiveCell >", () => {
+            it("should focus the button of the active (current) month cell", () => {
+                const otherButton = { focus: jasmine.createSpy("focus") };
+                const activeButton = { focus: jasmine.createSpy("focus") };
+                monthPicker.rows = [
+                    [
+                        { current: false },
+                        { current: true },
+                        { current: false },
+                    ],
+                ];
+                (monthPicker as any).cellButtons = {
+                    toArray: () => [
+                        { nativeElement: otherButton },
+                        { nativeElement: activeButton },
+                        { nativeElement: { focus: jasmine.createSpy() } },
+                    ],
+                };
+
+                monthPicker.focusActiveCell();
+
+                expect(activeButton.focus).toHaveBeenCalled();
+                expect(otherButton.focus).not.toHaveBeenCalled();
+            });
+
+            it("should do nothing when there is no active month cell", () => {
+                monthPicker.rows = [[{ current: false }]];
+                (monthPicker as any).cellButtons = {
+                    toArray: () => [
+                        { nativeElement: { focus: jasmine.createSpy() } },
+                    ],
+                };
+
+                expect(() => monthPicker.focusActiveCell()).not.toThrow();
+            });
+        });
     });
 });

--- a/packages/bits/src/lib/date-picker/date-picker-month-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-month-picker.component.ts
@@ -18,7 +18,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component, OnInit } from "@angular/core";
+import {
+    Component,
+    ElementRef,
+    OnInit,
+    QueryList,
+    ViewChildren,
+} from "@angular/core";
 import moment from "moment/moment";
 import { Moment } from "moment/moment";
 
@@ -30,6 +36,9 @@ import { DatePickerInnerComponent } from "./date-picker-inner.component";
     standalone: false,
 })
 export class MonthPickerComponent implements OnInit {
+    @ViewChildren("cellButton", { read: ElementRef })
+    private cellButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
     title: string;
     rows: any[] = [];
     maxMode: string;
@@ -69,5 +78,18 @@ export class MonthPickerComponent implements OnInit {
             },
             "month"
         );
+    }
+
+    /**
+     * Moves DOM focus to the month cell button representing the currently
+     * navigated/active month (the cell whose `current` flag is set), enabling
+     * roving-tabindex keyboard navigation across the grid.
+     */
+    public focusActiveCell(): void {
+        const cells = this.rows.flat();
+        const activeIndex = cells.findIndex((cell: any) => cell.current);
+        const activeButton = this.cellButtons?.toArray()[activeIndex];
+
+        activeButton?.nativeElement.focus();
     }
 }

--- a/packages/bits/src/lib/date-picker/date-picker-month-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-month-picker.component.ts
@@ -81,9 +81,8 @@ export class MonthPickerComponent implements OnInit {
     }
 
     /**
-     * Moves DOM focus to the month cell button representing the currently
-     * navigated/active month (the cell whose `current` flag is set), enabling
-     * roving-tabindex keyboard navigation across the grid.
+     * Focuses the month cell button for the currently active month (the cell
+     * whose `current` flag is set), for roving-tabindex keyboard navigation.
      */
     public focusActiveCell(): void {
         const cells = this.rows.flat();

--- a/packages/bits/src/lib/date-picker/date-picker-year-picker.component.html
+++ b/packages/bits/src/lib/date-picker/date-picker-year-picker.component.html
@@ -8,7 +8,6 @@
                     icon="caret-left"
                     displayStyle="action"
                     (click)="datePicker.move(-1, $event)"
-                    tabindex="-1"
                 ></button>
             </th>
             <th [attr.colspan]="3">
@@ -26,7 +25,6 @@
                             datePicker.datepickerMode === datePicker.maxMode
                     }"
                     (click)="datePicker.toggleMode($event)"
-                    tabindex="-1"
                 >
                     <span>{{ title }}</span>
                 </button>
@@ -38,7 +36,6 @@
                     icon="caret-right"
                     displayStyle="action"
                     (click)="datePicker.move(1, $event)"
-                    tabindex="-1"
                 ></button>
             </th>
         </tr>
@@ -49,14 +46,15 @@
                 <button
                     nui-button
                     type="button"
+                    #cellButton
                     displayStyle="action"
                     [ngClass]="{
                         selected: cell.selected,
                         disabled: cell.disabled
                     }"
                     [disabled]="cell.disabled"
+                    [attr.tabindex]="cell.current ? 0 : -1"
                     (click)="datePicker.select(cell.date, $event)"
-                    tabindex="-1"
                 >
                     <span [ngClass]="{ 'text-info': cell.current }">{{
                         cell.label

--- a/packages/bits/src/lib/date-picker/date-picker-year-picker.component.spec.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-year-picker.component.spec.ts
@@ -56,7 +56,39 @@ describe("components >", () => {
         it("should check get starting year", () => {
             inner.yearRange = 10;
             const startingYear = (yearPicker as any).getStartingYear(2018);
-            expect(startingYear).toBe(2018);
+            expect(startingYear).toBe(2011);
+        });
+
+        describe("focusActiveCell >", () => {
+            it("should focus the button of the active (current) year cell", () => {
+                const otherButton = { focus: jasmine.createSpy("focus") };
+                const activeButton = { focus: jasmine.createSpy("focus") };
+                yearPicker.rows = [
+                    [{ current: false }, { current: true }],
+                ];
+                (yearPicker as any).cellButtons = {
+                    toArray: () => [
+                        { nativeElement: otherButton },
+                        { nativeElement: activeButton },
+                    ],
+                };
+
+                yearPicker.focusActiveCell();
+
+                expect(activeButton.focus).toHaveBeenCalled();
+                expect(otherButton.focus).not.toHaveBeenCalled();
+            });
+
+            it("should do nothing when there is no active year cell", () => {
+                yearPicker.rows = [[{ current: false }]];
+                (yearPicker as any).cellButtons = {
+                    toArray: () => [
+                        { nativeElement: { focus: jasmine.createSpy() } },
+                    ],
+                };
+
+                expect(() => yearPicker.focusActiveCell()).not.toThrow();
+            });
         });
     });
 });

--- a/packages/bits/src/lib/date-picker/date-picker-year-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-year-picker.component.ts
@@ -82,9 +82,8 @@ export class YearPickerComponent implements OnInit {
     }
 
     /**
-     * Moves DOM focus to the year cell button representing the currently
-     * navigated/active year (the cell whose `current` flag is set), enabling
-     * roving-tabindex keyboard navigation across the grid.
+     * Focuses the year cell button for the currently active year (the cell
+     * whose `current` flag is set), for roving-tabindex keyboard navigation.
      */
     public focusActiveCell(): void {
         const cells = this.rows.flat();

--- a/packages/bits/src/lib/date-picker/date-picker-year-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker-year-picker.component.ts
@@ -18,7 +18,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import { Component, OnInit } from "@angular/core";
+import {
+    Component,
+    ElementRef,
+    OnInit,
+    QueryList,
+    ViewChildren,
+} from "@angular/core";
 import moment from "moment/moment";
 import { Moment } from "moment/moment";
 
@@ -30,6 +36,9 @@ import { DatePickerInnerComponent } from "./date-picker-inner.component";
     standalone: false,
 })
 export class YearPickerComponent implements OnInit {
+    @ViewChildren("cellButton", { read: ElementRef })
+    private cellButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
     title: string;
     rows: any[] = [];
 
@@ -72,9 +81,22 @@ export class YearPickerComponent implements OnInit {
         );
     }
 
+    /**
+     * Moves DOM focus to the year cell button representing the currently
+     * navigated/active year (the cell whose `current` flag is set), enabling
+     * roving-tabindex keyboard navigation across the grid.
+     */
+    public focusActiveCell(): void {
+        const cells = this.rows.flat();
+        const activeIndex = cells.findIndex((cell: any) => cell.current);
+        const activeButton = this.cellButtons?.toArray()[activeIndex];
+
+        activeButton?.nativeElement.focus();
+    }
+
     protected getStartingYear(year: number): number {
         return (
-            ((year - 1) / this.datePicker.yearRange) *
+            Math.floor((year - 1) / this.datePicker.yearRange) *
                 this.datePicker.yearRange +
             1
         );

--- a/packages/bits/src/lib/date-picker/date-picker.component.html
+++ b/packages/bits/src/lib/date-picker/date-picker.component.html
@@ -16,12 +16,19 @@
                 [ariaLabel]="ariaLabel"
             >
             </nui-textbox>
-            <nui-icon
-                class="nui-datepicker__icon"
+            <button
+                #toggleButton
+                nui-button
+                type="button"
+                displayStyle="action"
                 icon="calendar"
-                aria-hidden="true"
+                class="nui-datepicker__icon"
                 [iconColor]="getIconColor()"
-            ></nui-icon>
+                [disabled]="isDisabled"
+                [ariaLabel]="'Open calendar'"
+                [attr.aria-expanded]="overlay.showing"
+                (click)="onToggleClick($event)"
+            ></button>
         </div>
         <nui-overlay
             #overlay
@@ -68,8 +75,8 @@
         [handleTimezone]="handleTimezone"
         [value]="value"
     >
-        <nui-day-picker tabindex="0"></nui-day-picker>
-        <nui-month-picker tabindex="0"></nui-month-picker>
-        <nui-year-picker tabindex="0"></nui-year-picker>
+        <nui-day-picker></nui-day-picker>
+        <nui-month-picker></nui-month-picker>
+        <nui-year-picker></nui-year-picker>
     </nui-date-picker-inner>
 </ng-template>

--- a/packages/bits/src/lib/date-picker/date-picker.component.html
+++ b/packages/bits/src/lib/date-picker/date-picker.component.html
@@ -27,7 +27,6 @@
                 [disabled]="isDisabled"
                 [ariaLabel]="'Open calendar'"
                 [attr.aria-expanded]="overlay.showing"
-                (click)="onToggleClick($event)"
             ></button>
         </div>
         <nui-overlay

--- a/packages/bits/src/lib/date-picker/date-picker.component.less
+++ b/packages/bits/src/lib/date-picker/date-picker.component.less
@@ -75,12 +75,16 @@
         z-index: (@zindex-active + 1);
 
         // The calendar toggle is a real <button> (for keyboard accessibility),
-        // but it must visually match the previous standalone <nui-icon>. Size it
-        // to the default icon footprint instead of the default 30x30 icon-only
-        // action-button box, so it keeps the same footprint and alignment.
+        // but it must visually match the previous standalone <nui-icon>. Keep the
+        // 16px icon glyph while ensuring the interactive button meets the WCAG 2.2
+        // (2.5.8) minimum 24x24px touch-target size so it passes the axe
+        // `target-size` / `target-offset` checks.
         &.btn.is-empty {
-            min-width: @icon-size-default;
-            min-height: @icon-size-default;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 24px;
+            min-height: 24px;
             padding: 0;
         }
 

--- a/packages/bits/src/lib/date-picker/date-picker.component.less
+++ b/packages/bits/src/lib/date-picker/date-picker.component.less
@@ -4,6 +4,8 @@
 
 @nui-datepicker-calendar-min-cell-size: 30px;
 @nui-datepicker-width: 135px;
+// WCAG 2.2 (2.5.8) minimum touch-target size
+@nui-datepicker-min-touch-target-size: 24px;
 // 9 * 30 + 2 * 10 (9 cells + paddings)
 @nui-datepicker-popup-min-height: (
     9 * @nui-datepicker-calendar-min-cell-size + 2 * @nui-space-sm
@@ -74,17 +76,15 @@
         transform: translateY(-50%);
         z-index: (@zindex-active + 1);
 
-        // The calendar toggle is a real <button> (for keyboard accessibility),
-        // but it must visually match the previous standalone <nui-icon>. Keep the
-        // 16px icon glyph while ensuring the interactive button meets the WCAG 2.2
-        // (2.5.8) minimum 24x24px touch-target size so it passes the axe
-        // `target-size` / `target-offset` checks.
+        // Real <button> for a11y, must still look like the old icon-only glyph.
+        // Enlarges only the hit area to the WCAG 2.5.8 24x24 min touch target
+        // (axe target-size/target-offset), keeping the 16px icon glyph.
         &.btn.is-empty {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            min-width: 24px;
-            min-height: 24px;
+            min-width: @nui-datepicker-min-touch-target-size;
+            min-height: @nui-datepicker-min-touch-target-size;
             padding: 0;
         }
 

--- a/packages/bits/src/lib/date-picker/date-picker.component.less
+++ b/packages/bits/src/lib/date-picker/date-picker.component.less
@@ -70,8 +70,19 @@
         pointer-events: auto;
         position: absolute;
         right: @nui-space-xs + @nui-space-xxs;
-        top: @nui-space-xs + @nui-space-xxs;
+        top: 50%;
+        transform: translateY(-50%);
         z-index: (@zindex-active + 1);
+
+        // The calendar toggle is a real <button> (for keyboard accessibility),
+        // but it must visually match the previous standalone <nui-icon>. Size it
+        // to the default icon footprint instead of the default 30x30 icon-only
+        // action-button box, so it keeps the same footprint and alignment.
+        &.btn.is-empty {
+            min-width: @icon-size-default;
+            min-height: @icon-size-default;
+            padding: 0;
+        }
 
         &.disabled {
             pointer-events: none;

--- a/packages/bits/src/lib/date-picker/date-picker.component.spec.ts
+++ b/packages/bits/src/lib/date-picker/date-picker.component.spec.ts
@@ -32,6 +32,7 @@ import momentTz from "moment-timezone";
 
 import { DayPickerComponent } from "./date-picker-day-picker.component";
 import { DatePickerInnerComponent } from "./date-picker-inner.component";
+import { DatePickerKeyboardService } from "./date-picker-keyboard.service";
 import { MonthPickerComponent } from "./date-picker-month-picker.component";
 import { DatePickerSpecHelpers } from "./date-picker-spec-helpers/date-picker-spec-helpers";
 import { YearPickerComponent } from "./date-picker-year-picker.component";
@@ -314,6 +315,148 @@ describe("components >", () => {
                         datePickerDefaults.dateFormat
                     );
                 });
+            });
+        });
+
+        describe("keyboard accessibility >", () => {
+            const getToggleButton = (): HTMLButtonElement =>
+                debugElement.query(By.css("button.nui-datepicker__icon"))
+                    .nativeElement;
+
+            beforeEach(() => {
+                componentInstance.inline = false;
+                fixture.detectChanges();
+            });
+
+            it("should render the calendar toggle as an accessible, focusable button", () => {
+                const toggleButton = debugElement.query(
+                    By.css("button.nui-datepicker__icon")
+                );
+
+                expect(toggleButton).toBeTruthy();
+                expect(toggleButton.attributes["aria-label"]).toBe(
+                    "Open calendar"
+                );
+                expect(toggleButton.attributes["aria-expanded"]).toBe("false");
+            });
+
+            it("should reflect aria-expanded when the overlay is opened", () => {
+                componentInstance.overlay.toggle();
+                fixture.detectChanges();
+
+                const toggleButton = debugElement.query(
+                    By.css("button.nui-datepicker__icon")
+                );
+
+                expect(toggleButton.attributes["aria-expanded"]).toBe("true");
+            });
+
+            it("should toggle the overlay exactly once when the toggle button is clicked", () => {
+                spyOn(componentInstance.overlay, "toggle").and.callThrough();
+
+                getToggleButton().click();
+
+                expect(componentInstance.overlay.toggle).toHaveBeenCalledTimes(
+                    1
+                );
+            });
+
+            it("should open the calendar on ArrowDown when it is closed", fakeAsync(() => {
+                expect(componentInstance.overlay.showing).toBeFalsy();
+
+                debugElement.nativeElement.dispatchEvent(
+                    new KeyboardEvent("keydown", {
+                        code: "ArrowDown",
+                        bubbles: true,
+                        cancelable: true,
+                    })
+                );
+                tick();
+
+                expect(componentInstance.overlay.showing).toBeTruthy();
+            }));
+
+            it("should close the calendar and restore focus to the toggle button on Escape", () => {
+                componentInstance.overlay.show();
+                fixture.detectChanges();
+
+                const toggleButton = getToggleButton();
+                spyOn(toggleButton, "focus");
+
+                expect(
+                    (componentInstance as any).keyboardService["toggleButton"]
+                ).toBe(toggleButton);
+
+                debugElement.nativeElement.dispatchEvent(
+                    new KeyboardEvent("keydown", {
+                        code: "Escape",
+                        bubbles: true,
+                        cancelable: true,
+                    })
+                );
+
+                expect(componentInstance.overlay.showing).toBeFalsy();
+                expect(toggleButton.focus).toHaveBeenCalled();
+            });
+
+            it("should navigate to the next day in the grid on ArrowRight", fakeAsync(() => {
+                const startDate = moment().startOf("month").add(10, "days");
+                componentInstance.writeValue(startDate.clone());
+                componentInstance.overlay.show();
+                fixture.detectChanges();
+
+                debugElement.nativeElement.dispatchEvent(
+                    new KeyboardEvent("keydown", {
+                        code: "ArrowRight",
+                        bubbles: true,
+                        cancelable: true,
+                    })
+                );
+                fixture.detectChanges();
+                tick();
+
+                expect(
+                    componentInstance._datePicker.value?.isSame(
+                        startDate.clone().add(1, "days"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should navigate to the previous month on PageUp", fakeAsync(() => {
+                const startDate = moment().startOf("month").add(10, "days");
+                componentInstance.writeValue(startDate.clone());
+                componentInstance.overlay.show();
+                fixture.detectChanges();
+
+                debugElement.nativeElement.dispatchEvent(
+                    new KeyboardEvent("keydown", {
+                        code: "PageUp",
+                        bubbles: true,
+                        cancelable: true,
+                    })
+                );
+                fixture.detectChanges();
+                tick();
+
+                expect(
+                    componentInstance._datePicker.value?.isSame(
+                        startDate.clone().subtract(1, "months"),
+                        "day"
+                    )
+                ).toBeTruthy();
+            }));
+
+            it("should refocus the active grid cell when the view mode changes", () => {
+                const keyboardService =
+                    fixture.debugElement.injector.get<DatePickerKeyboardService>(
+                        DatePickerKeyboardService
+                    );
+                const focusSpy = spyOn(keyboardService, "focusActiveCell");
+
+                componentInstance._datePicker.modeChanged.next("month");
+
+                expect(focusSpy).toHaveBeenCalled();
             });
         });
     });

--- a/packages/bits/src/lib/date-picker/date-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker.component.ts
@@ -309,8 +309,8 @@ export class DatePickerComponent
             this.yearPicker
         );
 
-        // When the view switches between day/month/year, keep keyboard focus inside
-        // the newly rendered grid so arrow keys keep working without an extra Tab.
+        // Keep focus in the grid across day/month/year switches, so arrows
+        // keep working without an extra Tab.
         this._datePicker.modeChanged
             .pipe(takeUntil(this.onDestroy$))
             .subscribe(() => this.keyboardService.focusActiveCell());

--- a/packages/bits/src/lib/date-picker/date-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker.component.ts
@@ -27,6 +27,7 @@ import {
     EventEmitter,
     forwardRef,
     HostBinding,
+    HostListener,
     Input,
     OnChanges,
     OnDestroy,
@@ -51,7 +52,11 @@ import moment, { Moment } from "moment/moment";
 import { Subject, Subscription } from "rxjs";
 import { debounceTime, takeUntil } from "rxjs/operators";
 
+import { DayPickerComponent } from "./date-picker-day-picker.component";
 import { DatePickerInnerComponent } from "./date-picker-inner.component";
+import { DatePickerKeyboardService } from "./date-picker-keyboard.service";
+import { MonthPickerComponent } from "./date-picker-month-picker.component";
+import { YearPickerComponent } from "./date-picker-year-picker.component";
 import {
     datePickerDateFormats,
     datePickerDefaults,
@@ -83,6 +88,7 @@ import { TextboxComponent } from "../textbox/textbox.component";
             useExisting: forwardRef(() => DatePickerComponent),
             multi: true,
         },
+        DatePickerKeyboardService,
     ],
     styleUrls: ["./date-picker.component.less"],
     encapsulation: ViewEncapsulation.None,
@@ -187,10 +193,21 @@ export class DatePickerComponent
     @ViewChild(DatePickerInnerComponent)
     _datePicker: DatePickerInnerComponent;
 
+    @ViewChild(DayPickerComponent)
+    dayPicker: DayPickerComponent;
+
+    @ViewChild(MonthPickerComponent)
+    monthPicker: MonthPickerComponent;
+
+    @ViewChild(YearPickerComponent)
+    yearPicker: YearPickerComponent;
+
     @ViewChild("date") textbox: TextboxComponent;
 
     @ViewChild("popupArea", { static: true }) popupArea: ElementRef;
     @ViewChild(OverlayComponent) public overlay: OverlayComponent;
+    @ViewChild("toggleButton", { read: ElementRef })
+    toggleButtonRef: ElementRef<HTMLButtonElement>;
 
     public onDestroy$ = new Subject<void>();
     public customContainer: ElementRef | undefined;
@@ -208,7 +225,10 @@ export class DatePickerComponent
     private momentDateFormat: string;
     private calendarChanged: Subscription;
 
-    constructor(private cd: ChangeDetectorRef) {}
+    constructor(
+        private cd: ChangeDetectorRef,
+        private keyboardService: DatePickerKeyboardService
+    ) {}
 
     public ngOnInit(): void {
         _defaults(this, datePickerDefaults);
@@ -278,6 +298,36 @@ export class DatePickerComponent
                         this._datePicker.datepickerMode = "day";
                     }
                 });
+        }
+
+        this.keyboardService.initService(
+            this._datePicker,
+            this.dayPicker,
+            this.overlay,
+            this.toggleButtonRef?.nativeElement,
+            this.monthPicker,
+            this.yearPicker
+        );
+
+        // When the view switches between day/month/year, keep keyboard focus inside
+        // the newly rendered grid so arrow keys keep working without an extra Tab.
+        this._datePicker.modeChanged
+            .pipe(takeUntil(this.onDestroy$))
+            .subscribe(() => this.keyboardService.focusActiveCell());
+    }
+
+    @HostListener("keydown", ["$event"])
+    public onKeyDown(event: KeyboardEvent): void {
+        this.keyboardService.onKeyDown(event);
+    }
+
+    public onToggleClick(event: MouseEvent): void {
+        // Prevent the click from also bubbling to the container's own toggle handler,
+        // which would otherwise immediately re-toggle the overlay shut.
+        event.stopPropagation();
+
+        if (!this.isDisabled) {
+            this.overlay.toggle();
         }
     }
 

--- a/packages/bits/src/lib/date-picker/date-picker.component.ts
+++ b/packages/bits/src/lib/date-picker/date-picker.component.ts
@@ -321,16 +321,6 @@ export class DatePickerComponent
         this.keyboardService.onKeyDown(event);
     }
 
-    public onToggleClick(event: MouseEvent): void {
-        // Prevent the click from also bubbling to the container's own toggle handler,
-        // which would otherwise immediately re-toggle the overlay shut.
-        event.stopPropagation();
-
-        if (!this.isDisabled) {
-            this.overlay.toggle();
-        }
-    }
-
     public updateTouchedState(): void {
         setTimeout(() => this.inputBlurred.emit(), 100);
         this.onTouched();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,13 +2687,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nova-ui/bits@~19.0.0":
-  version "19.0.2"
-  resolved "https://registry.npmjs.org/@nova-ui/bits/-/bits-19.0.2.tgz#5089215675a7637bcc92b3e66f983afd03b0380b"
-  integrity sha512-eTMbMieNURgbcAhj3lpDfgrDAcrmMeVNQZybpVXneSoMzfOQtkoQm03bYzfPFAcUfgtvQwVQkW1/7W+JYgI3QA==
-  dependencies:
-    tslib "^2.3.0"
-
 "@npmcli/agent@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz#2bb2b1c0a170940511554a7986ae2a8be9fedcce"


### PR DESCRIPTION
Introduces a dedicated DatePickerKeyboardService to handle open/close, arrow/page/home/end navigation, mode-aware grid movement (day/month/year), disabled-date skipping, and focus restoration on Escape. Updates the picker templates/components for roving tabindex and active-cell focusing, converts the calendar icon into an accessible toggle button with aria-expanded state, emits mode changes to keep focus in the active grid, and fixes year-grid range start calculation using floor division. Adds broad unit/spec coverage for the new keyboard and focus behavior.

## Frontend Pull Request Description

<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
