### PR TITLE
fix(dashboards): resolve nested interactive elements in list-leaf-item

### DIFF
--- a/packages/dashboards/src/lib/components/list-widget/list-elements/list-leaf-item/list-leaf-item.component.html
+++ b/packages/dashboards/src/lib/components/list-widget/list-elements/list-leaf-item/list-leaf-item.component.html
@@ -1,12 +1,4 @@
-<div
-    class="nui-list-leaf-item"
-    role="button"
-    tabindex="0"
-    (click)="onButtonClick()"
-    (keydown.enter)="onButtonClick()"
-    (keydown.space)="$event.preventDefault(); onButtonClick()"
->
-    <!-- TODO: NUI-6284 - list-leaf-item contains nested interactive elements -->
+<div class="nui-list-leaf-item">
     <div class="nui-list-leaf-item__info-container">
         <div class="nui-list-leaf-item__icon-container">
             @if (icon) {
@@ -17,7 +9,7 @@
         </div>
         <div class="nui-list-leaf-item__description">
             <a
-                class="nui-text-ellipsis"
+                class="nui-list-leaf-item__link nui-text-ellipsis"
                 [ngClass]="url ? '' : 'not-active'"
                 [attr.target]="url ? '_blank' : null"
                 [attr.href]="url || null"
@@ -32,6 +24,13 @@
         <ng-template #statusTpl>{{ status }}</ng-template>
     </div>
     @if (canNavigate) {
-    <nui-icon icon="caret-right" aria-hidden="true"></nui-icon>
+    <button
+        type="button"
+        class="nui-list-leaf-item__navigate-btn"
+        [attr.aria-label]="label ? 'Navigate to ' + label : 'Navigate'"
+        (click)="onButtonClick()"
+    >
+        <nui-icon icon="caret-right" aria-hidden="true"></nui-icon>
+    </button>
     }
 </div>

--- a/packages/dashboards/src/lib/components/list-widget/list-elements/list-leaf-item/list-leaf-item.component.less
+++ b/packages/dashboards/src/lib/components/list-widget/list-elements/list-leaf-item/list-leaf-item.component.less
@@ -1,6 +1,9 @@
 @import (reference) "@nova-ui/bits/sdk/less/nui-framework-variables";
+@import (reference) "@nova-ui/bits/sdk/less/mixins";
 
 .nui-list-leaf-item {
+    position: relative;
+    z-index: 0;
     width: 100%;
     display: flex;
     justify-content: space-between;
@@ -24,6 +27,26 @@
         grid-template-rows: 1fr 1fr;
         grid-template-columns: 1fr;
         max-width: 100%;
+    }
+
+    &__link {
+        position: relative;
+        z-index: 2;
+    }
+
+    &__navigate-btn {
+        all: unset;
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        cursor: pointer;
+
+        &:focus-visible {
+            .tab-focus();
+        }
     }
 }
 


### PR DESCRIPTION

## Frontend Pull Request Description
Fixes NUI-6284 - Removes nested interactive elements in list-leaf-item component (WCAG 4.1.2 violation).

**What changed:**

Anchor tag was nested inside a button div - now they're independent siblings.
Navigate button is absolutely positioned to cover the row via z-index layering.
Template and styling only. 

<!-- Provide a brief summary of the changes made in the frontend project. -->

## Checklist

- [ ] My code follows the [style guidelines](https://github.com/solarwinds/nova/blob/main/docs/STYLE_GUIDE.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have updated [change log](https://github.com/solarwinds/nova/blob/main/docs/CHANGELOG.md)
- [ ] I have been following [Definition of done](https://github.com/solarwinds/nova/blob/main/docs/DEFINITION_OF_DONE.md)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] New and existing unit tests pass locally and on CI with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- Add any relevant screenshots or images to help illustrate the changes. -->

## Additional Context (if necessary)

<!-- Provide any additional context or information that might be useful for reviewers. -->
